### PR TITLE
fix(company): bypass staffing for fully staffed teams

### DIFF
--- a/opc/engine.py
+++ b/opc/engine.py
@@ -1371,6 +1371,20 @@ class OPCEngine:
             )
         if not roles:
             return None
+        # Fully-staffed team: every role already has at least one assigned
+        # (non-placeholder) employee, so there is no hiring/staffing decision to
+        # make. Skip the staffing preflight entirely and let execution proceed
+        # with those employees. We key off the actual same-role employees rather
+        # than ``default_selection`` because a saved project default may pin a
+        # template for a role that is nonetheless already staffed. The prompt is
+        # still shown for not-fully-staffed teams, new teams, or when the user
+        # explicitly reopens it via ``/staffing`` (``force_manual_preflight``).
+        fully_staffed = all(
+            list(role.get("same_role_employee_ids") or [])
+            for role in roles
+        )
+        if fully_staffed and not force_manual_preflight:
+            return None
         role_agent_overrides = {
             str(role.get("role_id", "") or "").strip(): str(role.get("selected_agent", "") or "").strip()
             for role in roles

--- a/opc/layer2_organization/recruiter.py
+++ b/opc/layer2_organization/recruiter.py
@@ -250,7 +250,22 @@ def build_fallback_role_ids(plan: RecruitmentPlan) -> set[str]:
 
 
 def recruitment_plan_requires_confirmation(plan: RecruitmentPlan) -> bool:
-    return any(proposal.status in {"existing_staff", "proposed_hire"} for proposal in plan.proposals)
+    """Prompt for staffing confirmation only when the plan actually changes staffing.
+
+    A team that is already fully staffed (every role has an assigned employee
+    that the plan simply reuses) needs no confirmation. Confirmation is required
+    only when there is a genuine staffing decision:
+    - a new hire is proposed (``proposed_hire``), or
+    - an existing pool employee is assigned to a role that currently has no
+      employee of its own (``existing_staff`` with no same-role employees), i.e.
+      a not-fully-staffed or new team.
+    """
+    for proposal in plan.proposals:
+        if proposal.status == "proposed_hire":
+            return True
+        if proposal.status == "existing_staff" and not list(proposal.existing_employee_ids or []):
+            return True
+    return False
 
 
 def serialize_recruitment_plan(plan: RecruitmentPlan) -> dict[str, Any]:
@@ -429,6 +444,30 @@ class CompanyRecruiter:
             default="native",
         ) or "native"
         needs = self._collect_needs(runtime_spec)
+        # Fast path for a fully-staffed team: every role already has an active,
+        # non-placeholder same-role employee, so there is no staffing decision
+        # to make. Skip the (LLM) triage + global recruit entirely and reuse
+        # existing staff. This avoids slow recruiter calls and hiring prompts on
+        # every run when nothing about staffing needs to change.
+        fully_staffed_proposals = self._fully_staffed_proposals(needs, project_id=project_id)
+        if fully_staffed_proposals is not None:
+            plan_metadata = {
+                "project_id": project_id,
+                "execution_mode": str(getattr(runtime_spec, "metadata", {}).get("execution_mode", "company_mode") or "company_mode"),
+                "request_label": str(getattr(runtime_spec, "metadata", {}).get("request_label", "runtime") or "runtime"),
+                "recruitment_agent": selected_recruitment_agent,
+                "fully_staffed_fast_path": True,
+            }
+            plan = ensure_recruitment_plan_default_agents(
+                RecruitmentPlan(
+                    company_profile=str(getattr(runtime_spec, "profile", "corporate") or "corporate"),
+                    proposals=fully_staffed_proposals,
+                    recruiter_feedback=feedback,
+                    metadata=plan_metadata,
+                )
+            )
+            plan.summary = self.render_recruitment_summary(plan)
+            return plan
         triage_by_role = await self._triage_staffing_for_needs(
             needs,
             recruiter_feedback=feedback,
@@ -503,6 +542,70 @@ class CompanyRecruiter:
             summary=summary,
             metadata=plan_metadata,
         ))
+
+    @staticmethod
+    def _is_placeholder_employee(employee: Any) -> bool:
+        metadata = dict(getattr(employee, "metadata", {}) or {})
+        return bool(metadata.get("is_default_employee") or metadata.get("is_fallback_employee"))
+
+    def _fully_staffed_proposals(
+        self,
+        needs: list[RecruitmentNeed],
+        *,
+        project_id: str,
+    ) -> list[RecruitmentProposal] | None:
+        """Return reuse-existing-staff proposals when every role is already staffed.
+
+        Returns ``None`` (no fast path) if any role lacks an active,
+        non-placeholder same-role employee, so not-fully-staffed and new teams
+        still go through normal recruitment.
+        """
+        if not needs:
+            return None
+        proposals: list[RecruitmentProposal] = []
+        for need in needs:
+            same_role = [
+                employee
+                for employee in self.org_engine.list_employees(role_id=need.role_id)
+                if not self._is_placeholder_employee(employee)
+            ]
+            if not same_role:
+                return None
+            summaries = [
+                (
+                    employee,
+                    self._build_existing_employee_summary(
+                        employee,
+                        role_id=need.role_id,
+                        domains=[],
+                        project_id=project_id,
+                    ),
+                )
+                for employee in same_role
+            ]
+            employee, _ = max(
+                summaries,
+                key=lambda pair: float(pair[1].get("experience_score", 0.0) or 0.0),
+            )
+            recommendation = self._make_existing_employee_recommendation(
+                employee,
+                role_id=need.role_id,
+                domains=[],
+                project_id=project_id,
+                rationale="Reusing the employee already staffed for this role; no staffing change is needed.",
+            )
+            proposals.append(
+                RecruitmentProposal(
+                    role_id=need.role_id,
+                    status="existing_staff",
+                    rationale=recommendation.rationale,
+                    role_labels=[need.role_name] if need.role_name else [],
+                    existing_employee=recommendation,
+                    existing_employee_ids=[item.employee_id for item in same_role],
+                    metadata={"selection_source": "fully_staffed_fast_path"},
+                )
+            )
+        return proposals
 
     def render_recruitment_summary(self, plan: RecruitmentPlan) -> str:
         execution_mode = str(plan.metadata.get("execution_mode", "company_mode") or "company_mode")

--- a/tests/test_company_recruiter.py
+++ b/tests/test_company_recruiter.py
@@ -13,6 +13,8 @@ from opc.core.config import EmployeeConfig, OPCConfig, RoleConfig, TalentTemplat
 from opc.core.events import EventBus
 from opc.core.models import (
     ExecutionMode,
+    RecruitmentPlan,
+    RecruitmentProposal,
     RouterDecision,
     Task,
     WorkItemExecutionStrategy,
@@ -24,7 +26,11 @@ from opc.layer2_organization.org_engine import (
     OrgEngine,
     TASK_MODE_GENERAL_ROLE_ID,
 )
-from opc.layer2_organization.recruiter import CompanyRecruiter, build_recruitment_plan_from_payload
+from opc.layer2_organization.recruiter import (
+    CompanyRecruiter,
+    build_recruitment_plan_from_payload,
+    recruitment_plan_requires_confirmation,
+)
 from opc.layer2_organization.task_graph import TaskGraphScheduler
 from opc.layer2_organization.talent_market import TalentMarket
 from opc.layer5_memory.memory_manager import MemoryManager
@@ -491,6 +497,144 @@ class CompanyRecruiterFlowTests(unittest.IsolatedAsyncioTestCase):
             )
             self.assertEqual(senior_role["selected_agent"], "codex")
             await store.close()
+
+    async def test_fully_staffed_team_skips_recruitment_and_confirmation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            config = OPCConfig()
+            config.org.company_profile = "custom"
+            config.org.roles = [
+                RoleConfig(
+                    id="api_owner",
+                    name="API Owner",
+                    responsibility="Own API design and delivery.",
+                )
+            ]
+            config.org.employees = [
+                EmployeeConfig(
+                    employee_id="api-owner-existing",
+                    template_id="api-owner-existing",
+                    name="Existing API Owner",
+                    role_id="api_owner",
+                    description="An active employee already assigned to the API owner role.",
+                    category="engineering",
+                    domains=["api"],
+                    prompt_refs=[],
+                )
+            ]
+            llm = DummyRecruiterLLM()
+            engine, store = await self._build_engine(root, config, llm)
+            decision = RouterDecision(
+                mode=ExecutionMode.COMPANY_MODE,
+                company_profile="custom",
+                domains=[],
+            )
+            runtime_spec = engine.company_runtime_spec_builder.build_spec(
+                decision,
+                original_message="Improve the API documentation",
+            )
+
+            plan = await engine.company_recruiter.build_recruitment_plan(
+                runtime_spec,
+                domains=[],
+                project_id="proj1",
+            )
+
+            self.assertTrue(plan.metadata["fully_staffed_fast_path"])
+            self.assertEqual(llm.calls, [])
+            self.assertEqual(len(plan.proposals), 1)
+            proposal = plan.proposals[0]
+            self.assertEqual(proposal.status, "existing_staff")
+            self.assertEqual(proposal.existing_employee.employee_id, "api-owner-existing")
+            self.assertEqual(proposal.existing_employee_ids, ["api-owner-existing"])
+            self.assertFalse(recruitment_plan_requires_confirmation(plan))
+
+            self.assertIsNone(
+                engine._build_manual_staffing_checkpoint_payload(
+                    decision,
+                    "Improve the API documentation",
+                    runtime_spec,
+                    session_id="sess-fully-staffed",
+                    origin_channel="cli",
+                    origin_chat_id="",
+                    origin_thread_id="",
+                )
+            )
+            self.assertIsNotNone(
+                engine._build_manual_staffing_checkpoint_payload(
+                    decision,
+                    "Improve the API documentation",
+                    runtime_spec,
+                    session_id="sess-fully-staffed",
+                    origin_channel="cli",
+                    origin_chat_id="",
+                    origin_thread_id="",
+                    force_manual_preflight=True,
+                )
+            )
+            await store.close()
+
+    async def test_placeholder_only_role_keeps_staffing_preflight(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            config = OPCConfig()
+            config.org.company_profile = "custom"
+            config.org.roles = [
+                RoleConfig(
+                    id="api_owner",
+                    name="API Owner",
+                    responsibility="Own API design and delivery.",
+                )
+            ]
+            config.org.employees = [
+                EmployeeConfig(
+                    employee_id="api-owner-placeholder",
+                    template_id="fallback-empty-employee",
+                    name="Fallback API Owner",
+                    role_id="api_owner",
+                    description="A placeholder employee, not staffed capacity.",
+                    category="engineering",
+                    domains=["api"],
+                    prompt_refs=[],
+                    metadata={"is_fallback_employee": True},
+                )
+            ]
+            engine, store = await self._build_engine(root, config, DummyRecruiterLLM())
+            decision = RouterDecision(
+                mode=ExecutionMode.COMPANY_MODE,
+                company_profile="custom",
+                domains=[],
+            )
+            runtime_spec = engine.company_runtime_spec_builder.build_spec(
+                decision,
+                original_message="Improve the API documentation",
+            )
+
+            payload = engine._build_manual_staffing_checkpoint_payload(
+                decision,
+                "Improve the API documentation",
+                runtime_spec,
+                session_id="sess-placeholder-only",
+                origin_channel="cli",
+                origin_chat_id="",
+                origin_thread_id="",
+            )
+
+            self.assertIsNotNone(payload)
+            await store.close()
+
+    def test_existing_staff_without_same_role_employee_still_requires_confirmation(self) -> None:
+        plan = RecruitmentPlan(
+            proposals=[
+                RecruitmentProposal(
+                    role_id="api_owner",
+                    status="existing_staff",
+                    existing_employee_ids=[],
+                )
+            ]
+        )
+
+        self.assertTrue(recruitment_plan_requires_confirmation(plan))
 
     async def test_org_hire_existing_canonical_employee_staffs_requested_role(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
# Skip staffing workflow for fully staffed teams

## Issue

Company runs opened staffing selection, LLM triage, recruitment, and confirmation even when every role already had an active, non-placeholder employee assigned. This added unnecessary latency and prompted the user to approve staffing that was not changing.

## Fix

- Detect when every role has existing, active, non-placeholder same-role staff.
- Reuse those employees without opening the staffing preflight or invoking recruiter triage.
- Do not require recruitment confirmation when an `existing_staff` proposal only reuses incumbents.
- Keep manual staffing available through `force_manual_preflight`.
- Continue through the normal staffing flow when a role is unstaffed or only has placeholder employees.

## Tests

- Fully staffed teams bypass recruitment and confirmation.
- Manual staffing preflight remains available.
- Placeholder-only roles retain staffing preflight.
- `existing_staff` without an incumbent still requires confirmation.


