### PR TITLE
feat(llm): forward configured reasoning_effort to native LLM calls

### DIFF
--- a/config/llm_config.yaml
+++ b/config/llm_config.yaml
@@ -7,6 +7,8 @@ llm:
 
   temperature: 1
   max_tokens: 32768
+  # reasoning_effort: "high"  # optional; use a provider-supported level
+                              # such as low, medium, or high
   routing: {}
   fallback: {}
 

--- a/opc/core/config.py
+++ b/opc/core/config.py
@@ -273,6 +273,7 @@ class LLMConfig(BaseModel):
     fallback: dict[str, Any] = Field(default_factory=dict)
     temperature: float = 0.3
     max_tokens: int = 32768
+    reasoning_effort: str | None = None
     # Total input context window (tokens) for the active model. Set this when
     # the model is not mapped in litellm (e.g. proxy/self-hosted models like
     # doubao/minimax/glm), so the context-usage ring and compaction thresholds

--- a/opc/llm/provider.py
+++ b/opc/llm/provider.py
@@ -569,6 +569,8 @@ class LLMProvider:
             "max_tokens": max_tok,
             **kwargs,
         }
+        if self.config.reasoning_effort and "reasoning_effort" not in call_kwargs:
+            call_kwargs["reasoning_effort"] = self.config.reasoning_effort
         if self._api_base:
             call_kwargs["api_base"] = self._api_base
         if self._api_key:
@@ -715,6 +717,8 @@ class LLMProvider:
             "stream": True,
             **kwargs,
         }
+        if self.config.reasoning_effort and "reasoning_effort" not in call_kwargs:
+            call_kwargs["reasoning_effort"] = self.config.reasoning_effort
         if self._api_base:
             call_kwargs["api_base"] = self._api_base
         if self._api_key:

--- a/tests/test_llm_provider_reasoning_effort.py
+++ b/tests/test_llm_provider_reasoning_effort.py
@@ -64,6 +64,26 @@ class TestLLMProviderReasoningEffort(unittest.IsolatedAsyncioTestCase):
 
         assert completion.await_args.kwargs["reasoning_effort"] == "max"
 
+    async def test_chat_allows_per_call_reasoning_effort_override(self) -> None:
+        provider = LLMProvider(LLMConfig(
+            default_model="openai/gpt-5.6-luna",
+            reasoning_effort="high",
+        ))
+
+        with (
+            patch("opc.llm.provider._clamp_max_tokens", return_value=128),
+            patch(
+                "opc.llm.provider.litellm.acompletion",
+                new=AsyncMock(return_value=_completion_response()),
+            ) as completion,
+        ):
+            await provider.chat(
+                [{"role": "user", "content": "hello"}],
+                reasoning_effort="low",
+            )
+
+        assert completion.await_args.kwargs["reasoning_effort"] == "low"
+
     async def test_chat_stream_forwards_configured_reasoning_effort(self) -> None:
         provider = LLMProvider(LLMConfig(
             default_model="openai/gpt-5.6-luna",
@@ -87,6 +107,30 @@ class TestLLMProviderReasoningEffort(unittest.IsolatedAsyncioTestCase):
         assert events
         assert completion.await_args.kwargs["reasoning_effort"] == "max"
         assert completion.await_args.kwargs["stream"] is True
+
+    async def test_chat_stream_allows_per_call_reasoning_effort_override(self) -> None:
+        provider = LLMProvider(LLMConfig(
+            default_model="openai/gpt-5.6-luna",
+            reasoning_effort="high",
+        ))
+
+        with (
+            patch("opc.llm.provider._clamp_max_tokens", return_value=128),
+            patch(
+                "opc.llm.provider.litellm.acompletion",
+                new=AsyncMock(return_value=_completion_stream()),
+            ) as completion,
+        ):
+            events = [
+                event
+                async for event in provider.chat_stream(
+                    [{"role": "user", "content": "hello"}],
+                    reasoning_effort="low",
+                )
+            ]
+
+        assert events
+        assert completion.await_args.kwargs["reasoning_effort"] == "low"
 
     async def test_unset_reasoning_effort_is_not_added_to_requests(self) -> None:
         provider = LLMProvider(LLMConfig(default_model="openai/gpt-5.6-luna"))

--- a/tests/test_llm_provider_reasoning_effort.py
+++ b/tests/test_llm_provider_reasoning_effort.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from opc.core.config import LLMConfig
+from opc.llm.provider import LLMProvider
+
+
+def _completion_response() -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="ok", tool_calls=[]),
+                finish_reason="stop",
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+
+
+async def _completion_stream():
+    yield SimpleNamespace(
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    content="ok",
+                    reasoning=None,
+                    reasoning_content=None,
+                    thinking=None,
+                    tool_calls=[],
+                ),
+                finish_reason="stop",
+            )
+        ],
+    )
+
+
+class TestLLMProviderReasoningEffort(unittest.IsolatedAsyncioTestCase):
+    def test_config_retains_reasoning_effort(self) -> None:
+        config = LLMConfig.model_validate({
+            "default_model": "openai/gpt-5.6-luna",
+            "reasoning_effort": "max",
+        })
+
+        assert config.reasoning_effort == "max"
+
+    async def test_chat_forwards_configured_reasoning_effort(self) -> None:
+        provider = LLMProvider(LLMConfig(
+            default_model="openai/gpt-5.6-luna",
+            reasoning_effort="max",
+        ))
+
+        with (
+            patch("opc.llm.provider._clamp_max_tokens", return_value=128),
+            patch(
+                "opc.llm.provider.litellm.acompletion",
+                new=AsyncMock(return_value=_completion_response()),
+            ) as completion,
+        ):
+            await provider.chat([{"role": "user", "content": "hello"}])
+
+        assert completion.await_args.kwargs["reasoning_effort"] == "max"
+
+    async def test_chat_stream_forwards_configured_reasoning_effort(self) -> None:
+        provider = LLMProvider(LLMConfig(
+            default_model="openai/gpt-5.6-luna",
+            reasoning_effort="max",
+        ))
+
+        with (
+            patch("opc.llm.provider._clamp_max_tokens", return_value=128),
+            patch(
+                "opc.llm.provider.litellm.acompletion",
+                new=AsyncMock(return_value=_completion_stream()),
+            ) as completion,
+        ):
+            events = [
+                event
+                async for event in provider.chat_stream([
+                    {"role": "user", "content": "hello"},
+                ])
+            ]
+
+        assert events
+        assert completion.await_args.kwargs["reasoning_effort"] == "max"
+        assert completion.await_args.kwargs["stream"] is True
+
+    async def test_unset_reasoning_effort_is_not_added_to_requests(self) -> None:
+        provider = LLMProvider(LLMConfig(default_model="openai/gpt-5.6-luna"))
+
+        with (
+            patch("opc.llm.provider._clamp_max_tokens", return_value=128),
+            patch(
+                "opc.llm.provider.litellm.acompletion",
+                new=AsyncMock(return_value=_completion_response()),
+            ) as completion,
+        ):
+            await provider.chat([{"role": "user", "content": "hello"}])
+
+        assert "reasoning_effort" not in completion.await_args.kwargs


### PR DESCRIPTION
## What

Adds an optional `reasoning_effort` field to `LLMConfig` (e.g. `low`/`medium`/`high`/`max`) and forwards it to `litellm.acompletion` in both `chat()` and `chat_stream()` when set.

## Why

Native (OpenOPC Native agent) LLM calls had no way to control model reasoning effort. The field is opt-in: unset by default, so non-OpenAI providers and existing configs are unaffected. Callers can still override per-call via kwargs (the injection skips when `reasoning_effort` is already present).

## Scope

- Native `LLMProvider` calls only (both streaming and non-streaming paths — these are the only two `litellm.acompletion` call sites in the codebase).
- Subagents inherit the field automatically via `config.model_copy(deep=True)`.
- External agents (codex/claude/cursor/opencode) are out of scope: they do not use `LLMProvider`.

## Tests

`tests/test_llm_provider_reasoning_effort.py` — 4 tests covering config retention, chat forwarding, chat_stream forwarding, and the unset default (no param added). All pass locally.