### PR TITLE
fix(ci): install dev extras so pytest is available in smoke workflow

### DIFF
--- a/.github/workflows/external-agent-smoke.yml
+++ b/.github/workflows/external-agent-smoke.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install package
-        run: python -m pip install -e .
+        run: python -m pip install -e ".[dev]"
       - name: Run external-agent smoke checks
         run: >
           python -m pytest -q


### PR DESCRIPTION
## Problem

The `external-agent-smoke` workflow fails on all three platforms with:

```
No module named pytest
```

The install step was `pip install -e .`, which only pulls in runtime dependencies. `pytest` and `pytest-timeout` are declared in the `dev` optional-dependency group in `pyproject.toml` (lines 76-79) and therefore never installed.

## Why it was undetected

Every previous PR left this workflow in `action_required` state — fork PRs require maintainer approval before the job runs. The workflow never actually executed until PR #28, which surfaced the issue.

## Fix

One line: `pip install -e ".[dev]"`

This is independent of PR #28.