### PR TITLE
fix(agent): keep claude_code resume across failed/cancelled runs

### DIFF
--- a/opc/engine.py
+++ b/opc/engine.py
@@ -6603,7 +6603,8 @@ class OPCEngine:
                 has_resumable_external_session = bool(
                     gate_external_session
                 ) and external_session_status_allows_resume(
-                    gate_external_session.get("status")
+                    gate_external_session.get("status"),
+                    agent_type=gate_external_session.get("agent_type"),
                 )
                 if not has_resumable_external_session:
                     # The pin is a preference, not a fact: this work item has
@@ -6717,14 +6718,15 @@ class OPCEngine:
             task.metadata.pop("external_resume_checkpoint_session_updated_at", None)
             task.metadata.pop("external_resume_checkpoint_session_status", None)
             if isinstance(external_session, dict):
-                token_allowed = external_session_status_allows_resume(
-                    external_session.get("status")
-                )
                 agent_type = str(
                     external_session.get("agent_type")
                     or task.assigned_external_agent
                     or ""
                 ).strip()
+                token_allowed = external_session_status_allows_resume(
+                    external_session.get("status"),
+                    agent_type=agent_type,
+                )
                 assigned_agent_type = str(task.assigned_external_agent or "").strip()
                 token_candidates = [
                     str(external_session.get("resume_session_id") or "").strip(),
@@ -7100,7 +7102,7 @@ class OPCEngine:
             key=lambda session: _timestamp(getattr(session, "updated_at", None)),
         )
         latest_status = str(getattr(latest, "status", "") or "").strip().lower()
-        if external_session_status_allows_resume(latest_status):
+        if external_session_status_allows_resume(latest_status, agent_type=agent_type):
             return False
         latest_timestamp = _timestamp(getattr(latest, "updated_at", None))
         checkpoint_timestamp = _timestamp(checkpoint_updated_at)

--- a/opc/layer3_agent/external_broker.py
+++ b/opc/layer3_agent/external_broker.py
@@ -33,6 +33,8 @@ from opc.layer2_organization.work_item_identity import projection_id_for_task, t
 from opc.layer2_organization.work_item_links import linked_work_item_id_for_task, set_linked_work_item_id
 from opc.layer3_agent.adapters.base import ExternalAgentAdapter
 from opc.layer3_agent.external_session_identity import (
+    NON_RESUMABLE_EXTERNAL_SESSION_STATUSES,
+    agent_resume_survives_run_failure,
     external_session_allows_resume,
     external_session_matches_provider_token,
     is_provider_session_token,
@@ -201,6 +203,13 @@ class ExternalAgentBroker:
             return False
         status = str(getattr(selected, "status", "") or "").strip().lower()
         if status in {"done", "suspended"}:
+            return True
+        if (
+            agent_resume_survives_run_failure(adapter.agent_type)
+            and status in NON_RESUMABLE_EXTERNAL_SESSION_STATUSES
+        ):
+            # The run outcome is terminal-but-failed, yet this provider keeps
+            # its transcript on disk — the token still resumes the thread.
             return True
         # The newest row is alive but not finalized (running / awaiting_human /
         # awaiting_peer). An approval or peer park is not evidence the thread
@@ -2604,6 +2613,7 @@ class ExternalAgentBroker:
         elif (
             role_session_id
             and result.status in self._SESSION_INVALIDATING_RESULT_STATUSES
+            and not agent_resume_survives_run_failure(adapter.agent_type)
             and hasattr(self.store, "get_role_session_adapter_state")
             and hasattr(self.store, "update_role_session_adapter_state")
         ):
@@ -2647,7 +2657,10 @@ class ExternalAgentBroker:
                 logger.opt(exception=True).debug(
                     "Failed to clear provider-stream role state after terminal failure"
                 )
-        if result.status in self._SESSION_INVALIDATING_RESULT_STATUSES:
+        if (
+            result.status in self._SESSION_INVALIDATING_RESULT_STATUSES
+            and not agent_resume_survives_run_failure(adapter.agent_type)
+        ):
             failed_token = str(
                 resume_session_id
                 or provider_session_id

--- a/opc/layer3_agent/external_session_identity.py
+++ b/opc/layer3_agent/external_session_identity.py
@@ -20,15 +20,39 @@ NON_RESUMABLE_EXTERNAL_SESSION_STATUSES: frozenset[str] = frozenset({
     "startup_timeout",
 })
 
+# Agent types whose provider keeps the full session transcript on disk and can
+# replay it regardless of how the *launching run* ended.  Claude Code writes
+# every session to ``~/.claude/projects/<cwd>/<session-id>.jsonl`` and
+# ``--resume <id>`` restores it even after the spawning process failed, was
+# cancelled, or timed out — so a bad run outcome must not invalidate the
+# resume token and silently drop the whole conversation context.  Agents not
+# listed here keep the conservative status gate above.
+DURABLE_TRANSCRIPT_AGENT_TYPES: frozenset[str] = frozenset({
+    "claude_code",
+})
 
-def external_session_status_allows_resume(status: Any) -> bool:
+
+def agent_resume_survives_run_failure(agent_type: Any) -> bool:
+    return (
+        str(agent_type or "").strip().lower() in DURABLE_TRANSCRIPT_AGENT_TYPES
+    )
+
+
+def external_session_status_allows_resume(
+    status: Any,
+    *,
+    agent_type: Any = None,
+) -> bool:
+    if agent_resume_survives_run_failure(agent_type):
+        return True
     status = str(status or "").strip().lower()
     return status not in NON_RESUMABLE_EXTERNAL_SESSION_STATUSES
 
 
 def external_session_allows_resume(session: Any | None) -> bool:
     return session is not None and external_session_status_allows_resume(
-        getattr(session, "status", "")
+        getattr(session, "status", ""),
+        agent_type=getattr(session, "agent_type", None),
     )
 
 

--- a/tests/test_external_resume_survives_failed_run.py
+++ b/tests/test_external_resume_survives_failed_run.py
@@ -1,0 +1,439 @@
+"""Durable-transcript agents keep their resume token across failed runs.
+
+Claude Code persists every session transcript under
+``~/.claude/projects/<cwd>/<session-id>.jsonl`` and ``claude --resume <id>``
+replays it even when the launching run failed, was cancelled, or timed out.
+Treating a bad run outcome as "session dead" therefore silently drops the
+whole conversation context: the next turn starts a blank provider session
+and the agent answers as if the conversation never happened.
+
+These tests pin the new behavior:
+
+- ``external_session_status_allows_resume`` / ``select_best_external_resume_session``
+  / ``provider_token_from_external_session`` treat terminal-but-failed rows of
+  durable-transcript agents (claude_code) as resumable.
+- Broker restore re-seeds ``--resume`` from a failed/cancelled claude_code row.
+- Broker persist keeps the role token and task resume pin after a failed
+  claude_code run.
+- Codex (no durability claim) keeps the pre-existing conservative gate.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+from opc.core.models import (
+    ApprovalAction,
+    ApprovalDecision,
+    DelegationRoleSession,
+    ExternalSession,
+    RiskLevel,
+    Task,
+    TaskResult,
+    TaskStatus,
+)
+from opc.database.store import OPCStore
+from opc.layer3_agent.external_broker import ExternalAgentBroker
+from opc.layer3_agent.external_session_identity import (
+    agent_resume_survives_run_failure,
+    external_session_status_allows_resume,
+    provider_token_from_external_session,
+    select_best_external_resume_session,
+)
+
+
+class IdentityHelpersDurableAgentTests(unittest.TestCase):
+    def test_status_gate_still_blocks_non_durable_agents(self) -> None:
+        self.assertFalse(external_session_status_allows_resume("failed"))
+        self.assertFalse(
+            external_session_status_allows_resume("failed", agent_type="codex")
+        )
+        self.assertFalse(
+            external_session_status_allows_resume("cancelled", agent_type="opencode")
+        )
+
+    def test_status_gate_passes_durable_agent_for_all_statuses(self) -> None:
+        for status in (
+            "failed",
+            "cancelled",
+            "hard_timeout",
+            "idle_timeout",
+            "startup_timeout",
+            "denied",
+            "rejected",
+        ):
+            self.assertTrue(
+                external_session_status_allows_resume(
+                    status, agent_type="claude_code"
+                ),
+                status,
+            )
+
+    def test_capability_lookup_normalizes_input(self) -> None:
+        self.assertTrue(agent_resume_survives_run_failure("claude_code"))
+        self.assertTrue(agent_resume_survives_run_failure(" Claude_Code "))
+        self.assertFalse(agent_resume_survives_run_failure("codex"))
+        self.assertFalse(agent_resume_survives_run_failure(""))
+        self.assertFalse(agent_resume_survives_run_failure(None))
+
+    def test_newer_failed_claude_row_still_selected_for_resume(self) -> None:
+        now = datetime.now()
+        older = ExternalSession(
+            agent_type="claude_code",
+            project_id="proj1",
+            session_id="sess-cc",
+            status="done",
+            metadata={"resume_session_id": "sess-cc"},
+            updated_at=now - timedelta(minutes=1),
+        )
+        newer = ExternalSession(
+            agent_type="claude_code",
+            project_id="proj1",
+            session_id="sess-cc",
+            status="failed",
+            metadata={"resume_session_id": "sess-cc"},
+            updated_at=now,
+        )
+
+        selected, token = select_best_external_resume_session(
+            [older, newer],
+            agent_type="claude_code",
+            project_id="proj1",
+        )
+
+        self.assertIs(selected, newer)
+        self.assertEqual(token, "sess-cc")
+
+    def test_newer_failed_codex_row_keeps_vetoing(self) -> None:
+        now = datetime.now()
+        newer = ExternalSession(
+            agent_type="codex",
+            project_id="proj1",
+            session_id="thread-full",
+            status="failed",
+            metadata={"resume_session_id": "thread-full"},
+            updated_at=now,
+        )
+
+        selected, token = select_best_external_resume_session(
+            [newer],
+            agent_type="codex",
+            project_id="proj1",
+        )
+
+        self.assertIsNone(selected)
+        self.assertEqual(token, "")
+
+    def test_provider_token_extracted_from_failed_claude_row(self) -> None:
+        row = ExternalSession(
+            agent_type="claude_code",
+            project_id="proj1",
+            session_id="sess-cc",
+            status="cancelled",
+            metadata={"resume_session_id": "sess-cc"},
+        )
+        self.assertEqual(
+            provider_token_from_external_session(
+                row, agent_type="claude_code", project_id="proj1"
+            ),
+            "sess-cc",
+        )
+
+    def test_provider_token_still_empty_for_failed_codex_row(self) -> None:
+        row = ExternalSession(
+            agent_type="codex",
+            project_id="proj1",
+            session_id="thread-x",
+            status="failed",
+            metadata={"resume_session_id": "thread-x"},
+        )
+        self.assertEqual(
+            provider_token_from_external_session(
+                row, agent_type="codex", project_id="proj1"
+            ),
+            "",
+        )
+
+
+class _ApprovalStub:
+    async def authorize_external_action(self, task, agent_name, metadata, on_progress=None):
+        return True, ApprovalDecision(
+            action=ApprovalAction.AUTO_APPROVE,
+            risk_level=RiskLevel.LOW,
+            rationale="ok",
+            confidence=1.0,
+            policy_source="test",
+        )
+
+    async def authorize_tool_call(self, task, tool_name, arguments, metadata=None, on_progress=None):
+        return True, ApprovalDecision(
+            action=ApprovalAction.AUTO_APPROVE,
+            risk_level=RiskLevel.LOW,
+            rationale="ok",
+            confidence=1.0,
+            policy_source="test",
+        )
+
+
+class _MiniAdapter:
+    """Minimal test double — just what _persist_session / restore need."""
+
+    def __init__(self, *, agent_type: str, can_resume_blank: bool = False) -> None:
+        self.agent_type = agent_type
+        self.config = SimpleNamespace(
+            run_mode="exec",
+            session_mode="auto",
+            session_id="",
+            resume_session_flag="--resume",
+        )
+        self._can_resume_blank = can_resume_blank
+
+    def supports_session_resume(self) -> bool:
+        return True
+
+    def can_resume_without_session_id(self) -> bool:
+        return self._can_resume_blank
+
+
+class BrokerResumeSurvivesFailedRunTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.store = OPCStore(db_path=Path(self._tmpdir.name) / "store.db")
+        await self.store.initialize()
+        self.role_session_id = "role-runtime::run-cc::cto"
+        await self.store.save_delegation_role_session(
+            DelegationRoleSession(
+                role_session_id=self.role_session_id,
+                run_id="run-cc",
+                role_id="cto",
+            )
+        )
+        self.broker = ExternalAgentBroker(self.store, _ApprovalStub())
+
+    async def asyncTearDown(self) -> None:
+        await self.store.close()
+        self._tmpdir.cleanup()
+
+    def _task(self, *, task_id: str = "task-new", with_role: bool = True) -> Task:
+        metadata = (
+            {"delegation_role_session_id": self.role_session_id}
+            if with_role
+            else {}
+        )
+        return Task(
+            id=task_id, title="t", description="",
+            assigned_to="cto",
+            status=TaskStatus.PENDING,
+            project_id="proj1", session_id="sess-a",
+            metadata=metadata,
+        )
+
+    async def test_restore_keeps_claude_role_token_after_terminal_failure(self) -> None:
+        # Mirror of the codex rejection test: the newest row for the token
+        # finalized "failed", but claude transcripts survive the run, so the
+        # preconfigured resume pin must be kept, not cleared.
+        token = "sess-terminal"
+        await self.store.update_role_session_adapter_state(
+            self.role_session_id,
+            "claude_code",
+            {
+                "resume_session_id": token,
+                "provider_session_id": token,
+                "last_task_id": "task-old",
+            },
+        )
+        await self.store.save_external_session(ExternalSession(
+            agent_type="claude_code",
+            project_id="proj1",
+            session_id=token,
+            opc_session_id=self.role_session_id,
+            task_id="task-failed",
+            workspace_path="/tmp/ws",
+            run_mode="exec",
+            status="failed",
+            metadata={
+                "resume_session_id": token,
+                "provider_session_id": token,
+            },
+        ))
+        adapter = _MiniAdapter(agent_type="claude_code")
+        adapter.config.session_mode = "resume"
+        adapter.config.session_id = token
+        task = self._task()
+        task.metadata.update({
+            "external_resume_session_id": token,
+            "external_resume_session_scope_id": "sess-a",
+            "external_resume_agent_type": "claude_code",
+        })
+
+        await self.broker._restore_session_resume_from_store(adapter, task)
+
+        self.assertEqual(adapter.config.session_mode, "resume")
+        self.assertEqual(adapter.config.session_id, token)
+        self.assertIsNotNone(await self.store.get_role_session_adapter_state(
+            self.role_session_id,
+            "claude_code",
+        ))
+        self.assertEqual(
+            task.metadata.get("external_resume_session_id"), token
+        )
+
+    async def test_restore_reseeds_resume_from_cancelled_claude_row(self) -> None:
+        # No role state (task-mode turn): the only trace is an
+        # ExternalSession row whose run was cancelled mid-flight. The next
+        # turn must resume that provider session instead of starting blank.
+        token = "sess-cancelled"
+        await self.store.save_external_session(ExternalSession(
+            agent_type="claude_code",
+            project_id="proj1",
+            session_id=token,
+            opc_session_id="sess-a",
+            task_id="task-new",
+            workspace_path="/tmp/ws",
+            run_mode="exec",
+            status="cancelled",
+            metadata={
+                "resume_session_id": token,
+                "provider_session_id": token,
+            },
+        ))
+        adapter = _MiniAdapter(agent_type="claude_code")
+        task = self._task(with_role=False)
+
+        await self.broker._restore_session_resume_from_store(adapter, task)
+
+        self.assertEqual(adapter.config.session_mode, "resume")
+        self.assertEqual(adapter.config.session_id, token)
+        self.assertEqual(
+            task.metadata.get("external_resume_session_id"), token
+        )
+
+    async def test_restore_still_starts_fresh_for_failed_codex_row(self) -> None:
+        token = "thread-failed"
+        await self.store.save_external_session(ExternalSession(
+            agent_type="codex",
+            project_id="proj1",
+            session_id=token,
+            opc_session_id="sess-a",
+            task_id="task-new",
+            workspace_path="/tmp/ws",
+            run_mode="exec",
+            status="failed",
+            metadata={
+                "resume_session_id": token,
+                "provider_session_id": token,
+            },
+        ))
+        adapter = _MiniAdapter(agent_type="codex")
+        task = self._task(with_role=False)
+
+        await self.broker._restore_session_resume_from_store(adapter, task)
+
+        self.assertNotEqual(adapter.config.session_mode, "resume")
+        self.assertEqual(adapter.config.session_id, "")
+
+    async def test_persist_failed_claude_run_keeps_role_token_and_pin(self) -> None:
+        # Mirror of test_failed_resume_clears_matching_older_role_token...:
+        # for claude_code the transcript survives, so a failed retry must not
+        # clear the role token or the task's resume metadata.
+        token = "sess-keep"
+        await self.store.update_role_session_adapter_state(
+            self.role_session_id,
+            "claude_code",
+            {
+                "resume_session_id": token,
+                "provider_session_id": token,
+                "last_task_id": "task-old",
+            },
+        )
+        adapter = _MiniAdapter(agent_type="claude_code")
+        adapter.config.session_mode = "resume"
+        adapter.config.session_id = token
+        task = self._task(task_id="task-retry")
+        task.metadata.update({
+            "external_resume_session_id": token,
+            "external_resume_session_scope_id": "sess-a",
+            "external_resume_agent_type": "claude_code",
+        })
+
+        await self.broker._persist_session(
+            adapter=adapter,
+            task=task,
+            workspace_path="/tmp/ws",
+            metadata={
+                "command": "claude --print",
+                "model": "(cli default)",
+                "resume_session_id": token,
+            },
+            result=TaskResult(
+                status=TaskStatus.FAILED,
+                content="network error mid-run",
+                artifacts={"resume_session_id": token},
+            ),
+        )
+
+        entry = await self.store.get_role_session_adapter_state(
+            self.role_session_id,
+            "claude_code",
+        )
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["resume_session_id"], token)
+        self.assertEqual(
+            task.metadata.get("external_resume_session_id"), token
+        )
+        self.assertNotIn("external_resume_fallback", task.metadata)
+
+    async def test_persist_failed_codex_run_still_clears(self) -> None:
+        token = "thread-clear"
+        await self.store.update_role_session_adapter_state(
+            self.role_session_id,
+            "codex",
+            {
+                "resume_session_id": token,
+                "provider_session_id": token,
+                "last_task_id": "task-old",
+            },
+        )
+        adapter = _MiniAdapter(agent_type="codex")
+        adapter.config.session_mode = "resume"
+        adapter.config.session_id = token
+        task = self._task(task_id="task-retry")
+        task.metadata.update({
+            "external_resume_session_id": token,
+            "external_resume_session_scope_id": "sess-a",
+            "external_resume_agent_type": "codex",
+        })
+
+        await self.broker._persist_session(
+            adapter=adapter,
+            task=task,
+            workspace_path="/tmp/ws",
+            metadata={
+                "command": "codex exec resume",
+                "model": "(cli default)",
+                "resume_session_id": token,
+            },
+            result=TaskResult(
+                status=TaskStatus.FAILED,
+                content="context window full",
+                artifacts={"resume_session_id": token},
+            ),
+        )
+
+        self.assertIsNone(await self.store.get_role_session_adapter_state(
+            self.role_session_id,
+            "codex",
+        ))
+        self.assertNotIn("external_resume_session_id", task.metadata)
+        self.assertEqual(
+            task.metadata.get("external_resume_fallback"),
+            "provider_terminal_failure",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

When a Claude Code run launched by OpenOPC fails, is cancelled by the user, or hits a timeout, the **next conversation turn silently starts a brand-new provider session** — the agent replies as if the conversation never happened ("I have no context of that").

Reproduction (observed in a real task-mode project):

1. Start a task-mode conversation with `claude_code` as the execution agent; chat a few turns (resume works, context accumulates).
2. Stop the running task (or let a run fail / time out).
3. Send the next message in the *same* conversation.
4. The spawned `claude` process gets no `--resume` flag, starts a fresh session with only the new Task Brief, and answers with no memory of the conversation.

In the affected project, 2 UI conversations fragmented into **8 separate Claude sessions** (`~/.claude/projects/<workspace>/`), one of them 249 user messages deep before it was dropped.

## Root cause

Cross-invocation continuity relies on `--resume <session-id>` seeded from the persisted `external_sessions` row. Resume eligibility is gated by `NON_RESUMABLE_EXTERNAL_SESSION_STATUSES` (`failed`, `cancelled`, `hard_timeout`, …) in `opc/layer3_agent/external_session_identity.py`, and the broker additionally clears the role token and the task's resume pin after a failed run.

That gate conflates two independent things: **the run's outcome** and **the provider thread's resumability**. Claude Code persists every transcript under `~/.claude/projects/<cwd>/<session-id>.jsonl`; `claude --resume <id>` replays it even when the launching process died mid-run. Marking the token dead throws the whole conversation away for no reason.

## Fix

- `external_session_identity.py`: new `DURABLE_TRANSCRIPT_AGENT_TYPES = {"claude_code"}` + `agent_resume_survives_run_failure()`. `external_session_status_allows_resume()` accepts an optional `agent_type`; `external_session_allows_resume()` reads the row's own `agent_type`, so `select_best_external_resume_session()` / `provider_token_from_external_session()` pick up the policy without signature changes.
- `external_broker.py`: `_stored_provider_token_allows_resume()` treats a terminal-but-failed newest row as resumable for durable agents; `_persist_session()` keeps the role token and the task resume pin after a failed run of a durable agent.
- `engine.py`: the three bare-status call sites (checkpoint-restore gate, checkpoint token seeding, checkpoint token veto) now pass the session's `agent_type`.

Codex / opencode / cursor keep the existing conservative behavior (no durability claim made for them); unfinalized `provider_stream` tokens also keep the strict rejection rule — only *terminal* statuses are affected.

## Testing

- New `tests/test_external_resume_survives_failed_run.py` (12 tests): identity-helper policy matrix, broker restore re-seeding `--resume` from failed/cancelled claude_code rows, persist keeping the pin, and codex mirrors asserting the conservative path is unchanged.
- Existing suites: `test_external_session_continuity.py` (all 22 pass unchanged — the codex veto/clear semantics are preserved), `test_company_runtime_suspend_resume.py`, `test_external_agent_monitoring.py`, `test_metadata_ownership.py`, `test_company_collaboration.py`, `test_parallel_runtime_isolation.py`, `test_wake_and_delivery.py`.
- Failure list is identical to the clean `origin/main` baseline on the same machine (5 pre-existing environment failures, GBK-path related), i.e. no regression.

## Scope

Python only — no frontend changes. Behavior changes only for `agent_type == "claude_code"`; other external agents are untouched.
