### PR TITLE
Fix saved custom org state across project switches

### DIFF
--- a/opc/plugins/office_ui/ws_handler.py
+++ b/opc/plugins/office_ui/ws_handler.py
@@ -530,6 +530,22 @@ class WSHandler:
         self.engine = engine
         self.dispatcher = Dispatcher(engine, self.chat_store)
         self._active_project_id = self._normalize_project_id(project_id)
+        if (
+            str(getattr(self, "_exec_mode", "") or "").strip().lower() in {"org", "custom"}
+            and getattr(engine, "config", None) is not None
+            and getattr(engine, "org_engine", None) is not None
+        ):
+            config_dir = Path(getattr(engine, "opc_home", None) or Path.cwd() / ".opc") / "config"
+            try:
+                active_org_id = read_org_index(config_dir)
+            except Exception as exc:
+                active_org_id = None
+                logger.warning(f"Failed to read active org while switching projects: {exc}")
+            if active_org_id and not self._load_active_org_config_into_engine(active_org_id):
+                logger.warning(
+                    f"Failed to restore active org '{active_org_id}' for project "
+                    f"'{self._active_project_id}': {getattr(self, '_last_org_load_error', '')}"
+                )
         self._refresh_engine_attachment_store()
 
     def _ensure_office_services(self) -> OfficeServices:

--- a/tests/test_org_saved_crud.py
+++ b/tests/test_org_saved_crud.py
@@ -178,6 +178,48 @@ def test_write_active_org_config_never_writes_reserved_corporate_saved_org(tmp_p
     assert (config_dir / "company_orgs" / f"org_{cfg.org.organization_id}_config.yaml").exists()
 
 
+def test_project_activation_reloads_active_saved_org(tmp_path):
+    from opc.core.config import OPCConfig
+    from opc.core.org_config import write_org_index
+    from opc.plugins.office_ui import ws_handler as wh
+
+    config_dir = tmp_path / ".opc" / "config"
+    _write_saved_org(config_dir, "splinter", organization_name="Splinter AI Company", roles_count=1)
+    write_org_index(config_dir, "splinter")
+
+    delegate_config = OPCConfig()
+    delegate_config.org.company_profile = "corporate"
+    delegate_config.org.organization_id = "corporate"
+    delegate_org_engine = SimpleNamespace(
+        config=delegate_config,
+        reload_from_config=MagicMock(),
+    )
+    delegate = SimpleNamespace(
+        project_id="shipdocs",
+        opc_home=tmp_path / ".opc",
+        config=delegate_config,
+        org_engine=delegate_org_engine,
+        talent_market=SimpleNamespace(config=delegate_config),
+        _ensure_attachment_store=MagicMock(),
+    )
+
+    handler = wh.WSHandler.__new__(wh.WSHandler)
+    handler.engine = SimpleNamespace(project_id="default")
+    handler.chat_store = MagicMock()
+    handler._exec_mode = "org"
+    handler._company_profile = "custom"
+
+    handler._on_service_engine_activated(delegate, "shipdocs")
+
+    assert handler.engine is delegate
+    assert delegate.config.org.company_profile == "custom"
+    assert delegate.config.org.organization_id == "splinter"
+    assert [role.id for role in delegate.config.org.roles] == ["role_0"]
+    assert delegate.org_engine.config is delegate.config
+    delegate.org_engine.reload_from_config.assert_called_once_with()
+    delegate._ensure_attachment_store.assert_called_once_with()
+
+
 def test_org_service_rejects_corporate_write_operations(tmp_path):
     from opc.core.config import OPCConfig
     from opc.plugins.office_ui.services.context import ModeState, OfficeServiceContext


### PR DESCRIPTION
## What changed

- reload the active saved organization whenever the Office UI activates a different project engine
- keep malformed or missing org-index state from crashing a project switch
- add a regression test proving a corporate-configured delegate is rebound to the active custom org

## Why

The Office UI could remain in `org/custom` mode while a newly activated project engine still carried the built-in Corporate configuration. The UI and active-org index then pointed at the saved organization, but organization mutations were rejected as `org_read_only`.

## Impact

Saved custom organizations remain editable after switching projects. The built-in Corporate architecture stays read-only.

## Validation

- `python -m pytest -q tests/test_org_saved_crud.py tests/test_role_update_handler.py tests/test_parallel_runtime_isolation.py -k 'org or project_switch or update_role'`
- 23 passed, 16 deselected
- live Office UI validation confirmed Splinter remained `custom` after switching to ShipDocs and the Add role control was enabled
