### PR TITLE
docs: add LICENSE, Code of Conduct, Contributing guide, and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Report a problem with OpenOPC
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug report!
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / output
+      render: shell
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OpenOPC version/commit, Python version, OS, and relevant package versions.
+      placeholder: |
+        - OpenOPC:
+        - Python:
+        - OS:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Community (Feishu / WeChat)
+    url: https://github.com/HKUDS/.github/blob/main/profile/README.md
+    about: Ask questions and chat with the OpenOPC community.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/HKUDS/OpenOPC/security/advisories/new
+    about: Privately report security vulnerabilities; do not open a public issue.
   - name: Community (Feishu / WeChat)
     url: https://github.com/HKUDS/.github/blob/main/profile/README.md
     about: Ask questions and chat with the OpenOPC community.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest an idea or enhancement for OpenOPC
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what is missing or hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+<!-- What does this PR do and why? -->
+
+## Related issue
+<!-- e.g. Closes #123 -->
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / chore
+
+## How was this tested?
+<!-- Commands run, scenarios covered -->
+
+## Checklist
+- [ ] I read the [Contributing guide](../CONTRIBUTING.md)
+- [ ] The change is focused and scoped to one thing
+- [ ] Tests / smoke checks pass locally (`python -m pytest`)
+- [ ] Docs updated if user-facing behavior changed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,10 +59,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement through the Feishu
-or WeChat community groups linked in the [README](README.md), or by opening a
-confidential report with the maintainers. All complaints will be reviewed and
-investigated promptly and fairly.
+reported privately to an administrator of the Feishu or WeChat community groups
+linked in the [README](README.md). Do not post report details in a public issue or
+group channel; ask an administrator to continue the conversation privately. All
+complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement through the Feishu
+or WeChat community groups linked in the [README](README.md), or by opening a
+confidential report with the maintainers. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ git clone https://github.com/<your-username>/OpenOPC
 cd OpenOPC
 uv venv --python 3.12
 source .venv/bin/activate
-uv pip install -e .
+uv pip install -e ".[dev]"
 uv run opc init
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to OpenOPC
+
+Thanks for your interest in improving OpenOPC! This guide covers how to set up, make changes, and submit them.
+
+## Ways to contribute
+- **Report bugs** and **request features** via the [issue templates](.github/ISSUE_TEMPLATE).
+- **Improve docs**, fix typos, add examples.
+- **Submit code** — bug fixes, new features, talent templates, channel providers.
+- **Discuss** in the Feishu / WeChat community groups linked in the [README](README.md).
+
+## Development setup
+OpenOPC requires **Python >= 3.10** (3.12 recommended). [`uv`](https://docs.astral.sh/uv/) is the recommended tool.
+
+```bash
+git clone https://github.com/<your-username>/OpenOPC
+cd OpenOPC
+uv venv --python 3.12
+source .venv/bin/activate
+uv pip install -e .
+uv run opc init
+```
+
+Run the UI with `opc ui` (needs Node.js >= 18 for the Office UI) or the CLI with `opc chat`.
+
+## Making changes
+1. **Fork** the repo and create a branch: `git checkout -b my-change`.
+2. Keep changes **focused** — one logical change per PR.
+3. Match the existing code style; add type hints where the surrounding code uses them.
+4. Update docs/README when you change user-facing behavior.
+
+## Testing
+```bash
+python -m pytest
+```
+The `external-agent-smoke` GitHub workflow also runs on pull requests.
+
+## Submitting a pull request
+1. Push your branch to your fork.
+2. Open a PR against `main` using the pull request template.
+3. Link the related issue (e.g. `Closes #123`).
+4. Make sure CI passes and respond to review feedback.
+
+## Code of Conduct
+By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenOPC Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported versions
+
+OpenOPC does not yet publish versioned releases. Security fixes are made on the
+latest `main` branch; older commits are not supported.
+
+## Reporting a vulnerability
+
+Please do not disclose suspected vulnerabilities in a public issue or discussion.
+Use GitHub's [private vulnerability reporting](https://github.com/HKUDS/OpenOPC/security/advisories/new)
+to send the maintainers:
+
+- the affected commit and environment;
+- impact and required preconditions;
+- a minimal, non-destructive reproduction; and
+- any suggested mitigation or regression test.
+
+Use synthetic credentials and loopback endpoints whenever possible. The
+maintainers will coordinate validation, remediation, and disclosure with the
+reporter through the private advisory.


### PR DESCRIPTION
## Summary
The README declares an MIT license (badge), but the repository has **no `LICENSE` file** — GitHub's license detection returns none and the community-health score is ~37%. This PR adds the standard community-health files so licensing and the contribution process are explicit.

## What's added
- **LICENSE** — standard MIT text, matching the README badge. Please confirm the copyright holder line (currently `OpenOPC Authors`) — happy to change it to HKUDS or your preferred entity.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (the widely-adopted standard). The enforcement contact points to the Feishu/WeChat community groups linked in the README; feel free to swap in a dedicated email.
- **CONTRIBUTING.md** — setup (`uv`), running, testing (`pytest` + the external-agent smoke), and the fork/PR flow.
- **.github/PULL_REQUEST_TEMPLATE.md**
- **.github/ISSUE_TEMPLATE/** — `bug_report.yml`, `feature_request.yml`, and `config.yml` (links to the community groups).

## Notes
- Docs/meta only — no code changes.
- The **copyright holder** (in LICENSE) and the **CoC enforcement contact** are the two things worth a maintainer tweak before merge.
