### PR TITLE
[codex] fix remote MCP Streamable HTTP compatibility

### DIFF
--- a/opc/mcp_client.py
+++ b/opc/mcp_client.py
@@ -168,9 +168,21 @@ class MCPRemoteConnection(_MCPConnectionBase):
 
         # Strategy 1: StreamableHTTP
         try:
-            from mcp.client.streamable_http import streamablehttp_client
+            from mcp.client import streamable_http
+            streamable_client = getattr(streamable_http, "streamablehttp_client", None)
+            if streamable_client is not None:
+                transport_context = streamable_client(self.url, headers=self.headers)
+            else:
+                streamable_client = streamable_http.streamable_http_client
+                http_client_factory = getattr(streamable_http, "create_mcp_http_client", None)
+                if http_client_factory is None:
+                    raise RuntimeError("MCP StreamableHTTP client does not support headers")
+                http_client = await self._exit_stack.enter_async_context(
+                    http_client_factory(headers=self.headers)
+                )
+                transport_context = streamable_client(self.url, http_client=http_client)
             transport = await self._exit_stack.enter_async_context(
-                streamablehttp_client(self.url, headers=self.headers)
+                transport_context
             )
             read_stream, write_stream = transport[0], transport[1]
             self._session = await self._exit_stack.enter_async_context(
@@ -208,6 +220,8 @@ class MCPRemoteConnection(_MCPConnectionBase):
         except Exception as exc:
             last_error = exc
             logger.debug(f"MCP remote '{self.name}' SSE also failed: {exc}")
+            await self._exit_stack.aclose()
+            self._exit_stack = AsyncExitStack()
 
         raise ConnectionError(
             f"Failed to connect to remote MCP server '{self.name}' at {self.url}: {last_error}"

--- a/tests/test_mcp_client_remote.py
+++ b/tests/test_mcp_client_remote.py
@@ -1,0 +1,107 @@
+import asyncio
+import unittest
+from unittest.mock import patch
+
+import mcp.client.streamable_http as streamable_http
+import mcp.client.sse as sse
+
+from opc.mcp_client import MCPRemoteConnection
+
+
+class _AsyncContext:
+    def __init__(self, value, events):
+        self.value = value
+        self.events = events
+
+    async def __aenter__(self):
+        self.events.append("enter")
+        return self.value
+
+    async def __aexit__(self, *args):
+        self.events.append("exit")
+
+
+class _Session:
+    def __init__(self, read, write):
+        self.serverInfo = {"name": "fixture", "version": "1"}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def initialize(self):
+        return self
+
+
+class _FailingSession(_Session):
+    async def initialize(self):
+        raise RuntimeError("fixture initialize failed")
+
+
+class RemoteMCPCompatibilityTests(unittest.TestCase):
+    def test_current_sdk_uses_http_client_and_closes_it(self):
+        events = []
+        http_client = object()
+        http_client_context = _AsyncContext(http_client, events)
+
+        def current(url, *, http_client):
+            self.assertEqual(url, "http://fixture/mcp")
+            self.assertIs(http_client, expected_http_client)
+            return _AsyncContext((object(), object()), events)
+
+        def create_client(headers):
+            self.assertEqual(headers, {"Authorization": "Bearer x"})
+            return http_client_context
+
+        expected_http_client = http_client
+        with patch.object(streamable_http, "streamable_http_client", current), \
+                patch.object(streamable_http, "create_mcp_http_client", create_client):
+            with patch.object(streamable_http, "streamablehttp_client", None, create=True):
+                with patch("opc.mcp_client.ClientSession", _Session):
+                    conn = MCPRemoteConnection("fixture", "http://fixture/mcp", {"Authorization": "Bearer x"})
+                    asyncio.run(conn.start())
+                    asyncio.run(conn.stop())
+        self.assertEqual(events, ["enter", "enter", "exit", "exit"])
+
+    def test_legacy_sdk_receives_headers_directly(self):
+        events = []
+        seen = {}
+
+        def legacy(url, headers=None):
+            seen.update(url=url, headers=headers)
+            return _AsyncContext((object(), object()), events)
+
+        with patch.object(streamable_http, "streamablehttp_client", legacy, create=True), \
+                patch.object(streamable_http, "streamable_http_client", None):
+            with patch("opc.mcp_client.ClientSession", _Session):
+                conn = MCPRemoteConnection("fixture", "http://fixture/mcp", {"X-Test": "yes"})
+                asyncio.run(conn.start())
+                asyncio.run(conn.stop())
+        self.assertEqual(seen, {"url": "http://fixture/mcp", "headers": {"X-Test": "yes"}})
+        self.assertEqual(events, ["enter", "exit"])
+
+    def test_failed_sse_attempt_closes_entered_contexts(self):
+        events = []
+
+        def modern(url, *, http_client):
+            return _AsyncContext((object(), object()), events)
+
+        def sse_transport(url, headers=None):
+            return _AsyncContext((object(), object()), events)
+
+        with patch.object(streamable_http, "streamable_http_client", modern), \
+                patch.object(streamable_http, "streamablehttp_client", None, create=True), \
+                patch.object(streamable_http, "create_mcp_http_client", lambda headers: _AsyncContext(object(), events)), \
+                patch.object(sse, "sse_client", sse_transport), \
+                patch("opc.mcp_client.ClientSession", _FailingSession):
+            conn = MCPRemoteConnection("fixture", "http://fixture/mcp")
+            with self.assertRaises(ConnectionError):
+                asyncio.run(conn.start())
+        self.assertEqual(events, ["enter", "enter", "exit", "exit", "enter", "exit"])
+        self.assertFalse(conn._exit_stack._exit_callbacks)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add forward compatibility for MCP SDK 2.0 while retaining the legacy Streamable HTTP client path used by the repository's currently supported MCP 1.x range.

Related to #41. Upstream `main` now pins `mcp>=1.28,<2`, and the reported remote Streamable HTTP failure no longer reproduces in that supported configuration. This PR is therefore a Draft pending maintainer direction on whether OpenOPC should also support MCP 2.x.

## Current upstream context

Commit `bdd28c80acbc92eb0b77440ad7eb87f0b997cc83` constrained the supported SDK to MCP 1.x. On that exact `main` commit with `mcp==1.28.1`, the public DeepWiki endpoint completed initialization, `tools/list`, and session shutdown successfully.

The patch remains useful only as an explicit MCP 2.x compatibility path; it is no longer required for the reported behavior under the repository's declared dependency range.

## Changes

- use the legacy `streamablehttp_client(url, headers=...)` path when available;
- use MCP 2.0's `streamable_http_client(url, http_client=...)` with `create_mcp_http_client(headers=...)` otherwise;
- manage the MCP 2.0 HTTP client through the connection's `AsyncExitStack`;
- close entered resources when both Streamable HTTP and SSE initialization fail;
- add regression coverage for current SDK, legacy SDK, header propagation, and failed-fallback cleanup.

## Validation

- latest upstream `main` + `mcp==1.28.1` + `https://mcp.deepwiki.com/mcp`: initialize, 3-tool discovery, and clean stop passed;
- this PR + `mcp==2.0.0` against the same endpoint: initialize, 3-tool discovery, and clean stop passed;
- `python -m pytest -q tests/test_mcp_client_remote.py`: 3 passed;
- `python -m compileall -q opc/mcp_client.py tests/test_mcp_client_remote.py`;
- `git diff --check`.

The full test suite could not be collected in the original environment because a Windows long-path failure occurred inside a deeply nested `litellm` benchmark fixture.
