### PR TITLE
feat(mcp): scope servers and tools by runtime context

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,27 @@ system:
 Native browser tools include `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_wait_for`, `browser_scroll`, `browser_select_option`, `browser_evaluate`, `browser_take_screenshot`, and `browser_close`.
 
 MCP servers can be added under `mcp_servers` in `system_config.yaml`. Local servers use stdio commands; remote servers use HTTP/SSE-style URLs. Discovered tools are registered with a server prefix to avoid collisions.
+
+Servers and their tools can optionally be scoped to specific organizations,
+projects, or runtime roles:
+
+```yaml
+mcp_servers:
+  - name: knowledge
+    type: remote
+    url: "https://mcp.example.com/sse"
+    enabled: true
+    tools_filter: ["search", "get_entity"]
+    organizations: ["adroyt"]
+    projects: ["research"]
+    roles: ["researcher", "reviewer"]
+```
+
+Empty scope lists preserve the existing global behavior, and `"*"` matches any
+value. Organization and project scopes are checked before the server is
+connected. Role scopes filter the schemas shown to an agent and are checked
+again when a tool is dispatched. A role-scoped tool without trusted runtime
+role context is denied.
 </details>
 
 ### Troubleshooting

--- a/config/system_config.yaml
+++ b/config/system_config.yaml
@@ -265,6 +265,10 @@ mcp_servers:
   enabled: false
   env: {}
   tools_filter: []
+  # Optional access scopes. Empty lists preserve global availability.
+  organizations: []
+  projects: []
+  roles: []
   startup_timeout: 30.0
 
 # Example: GitHub MCP server (uncomment and set GITHUB_TOKEN)
@@ -275,6 +279,9 @@ mcp_servers:
 #   env:
 #     GITHUB_TOKEN: "your-github-token"
 #   tools_filter: []
+#   organizations: ["default"]
+#   projects: ["research"]
+#   roles: ["researcher", "reviewer"]
 #   startup_timeout: 30.0
 
 # Example: filesystem MCP server

--- a/opc/core/config.py
+++ b/opc/core/config.py
@@ -909,6 +909,9 @@ class MCPServerConfig(BaseModel):
     enabled: bool = True
     env: dict[str, str] = Field(default_factory=dict)
     tools_filter: list[str] = Field(default_factory=list)
+    organizations: list[str] = Field(default_factory=list)
+    projects: list[str] = Field(default_factory=list)
+    roles: list[str] = Field(default_factory=list)
     startup_timeout: float = 30.0
 
 

--- a/opc/engine.py
+++ b/opc/engine.py
@@ -1028,6 +1028,12 @@ class OPCEngine:
         for server_cfg in self.config.system.mcp_servers:
             if not server_cfg.enabled:
                 continue
+            if not self._mcp_server_matches_runtime_scope(server_cfg):
+                logger.info(
+                    "MCP '{}' skipped outside organization/project scope",
+                    server_cfg.name,
+                )
+                continue
             try:
                 server_type = getattr(server_cfg, "type", "local") or "local"
                 if server_type == "remote":
@@ -1051,12 +1057,30 @@ class OPCEngine:
                         timeout=server_cfg.startup_timeout,
                     )
                 tool_filter = set(server_cfg.tools_filter) if server_cfg.tools_filter else None
-                tools = await self.mcp_manager.register_tools(conn, tool_filter)
+                tools = await self.mcp_manager.register_tools(
+                    conn,
+                    tool_filter,
+                    allowed_roles=server_cfg.roles or None,
+                )
                 for tool in tools:
                     self.tool_registry.register(tool)
                 logger.info(f"MCP '{server_cfg.name}' ({server_type}): registered {len(tools)} tools")
             except Exception as exc:
                 logger.warning(f"MCP '{server_cfg.name}' unavailable, skipping: {exc}")
+
+    def _mcp_server_matches_runtime_scope(self, server_cfg: Any) -> bool:
+        organization_id = str(self.config.org.organization_id or "").strip()
+        project_id = str(self.project_id or "default").strip()
+        return self._scope_allows(
+            server_cfg.organizations, organization_id
+        ) and self._scope_allows(
+            server_cfg.projects, project_id
+        )
+
+    @staticmethod
+    def _scope_allows(configured: list[str], actual: str) -> bool:
+        scope = {str(value).strip() for value in configured if str(value).strip()}
+        return not scope or "*" in scope or actual in scope
 
     def _register_collaboration_tools(self) -> None:
         if not self.communication:

--- a/opc/layer3_agent/native_agent.py
+++ b/opc/layer3_agent/native_agent.py
@@ -341,6 +341,10 @@ class NativeAgent:
         """Execute a task end-to-end."""
         self.role.status = AgentStatus.RUNNING
         self.role.current_task_id = task.id
+        # Runtime-owned context used by ToolRegistry's dispatch-time scope check.
+        # It is an attribute rather than model-authored metadata so a tool call
+        # cannot claim a different role.
+        task._tool_scope_role_id = self.role.role_id
 
         await self.event_bus.publish(OPCEvent(
             event_type="agent_status_changed",
@@ -633,7 +637,7 @@ class NativeAgent:
                     tool for tool in inherited
                     if tool not in _MULTI_TEAM_COORDINATION_NATIVE_TOOL_BLOCKLIST
                 ]
-            return inherited
+            return self._apply_role_tool_scope(inherited)
 
         configured_general = self._configured_general_tool_names(list(self.role.tools or []))
         company_mode = company_collaboration_enabled_for_task(task)
@@ -650,11 +654,22 @@ class NativeAgent:
         elif configured_general:
             allowed = set(configured_general)
         else:
-            return None
+            if not self.tool_registry.has_role_scoped_tools():
+                return None
+            allowed = self._registered_general_tool_names()
 
         if turn_mode in MULTI_TEAM_COORDINATION_TURN_MODES:
             allowed.difference_update(_MULTI_TEAM_COORDINATION_NATIVE_TOOL_BLOCKLIST)
-        return sorted(allowed)
+        return sorted(self._apply_role_tool_scope(allowed))
+
+    def _apply_role_tool_scope(self, names: list[str] | set[str]) -> list[str]:
+        role_id = str(self.role.role_id or "").strip()
+        allowed: list[str] = []
+        for name in names:
+            tool = self.tool_registry.get(name)
+            if tool is None or tool.allows_role(role_id):
+                allowed.append(name)
+        return allowed
 
     async def _build_runtime_prefetch_payload(
         self,

--- a/opc/layer4_tools/registry.py
+++ b/opc/layer4_tools/registry.py
@@ -77,6 +77,7 @@ class ToolDefinition:
         self_bounded_output: bool = False,
         preview_chars: int | None = None,
         company_effect_kind: str = COMPANY_EFFECT_UNKNOWN,
+        allowed_roles: list[str] | tuple[str, ...] | set[str] | None = None,
     ) -> None:
         self.name = name
         self.description = description
@@ -97,6 +98,20 @@ class ToolDefinition:
                 f"Unknown company tool-effect capability: {company_effect_kind}"
             )
         self.company_effect_kind = normalized_effect_kind
+        self.allowed_roles = frozenset(
+            str(role).strip() for role in (allowed_roles or []) if str(role).strip()
+        )
+
+    def allows_role(self, role_id: str | None) -> bool:
+        """Return whether this tool is available to a trusted runtime role."""
+
+        if not self.allowed_roles:
+            return True
+        normalized = str(role_id or "").strip()
+        return bool(
+            normalized
+            and (normalized in self.allowed_roles or "*" in self.allowed_roles)
+        )
 
     def to_schema(self) -> dict[str, Any]:
         return {
@@ -125,17 +140,31 @@ class ToolRegistry:
     def get(self, name: str) -> ToolDefinition | None:
         return self._tools.get(name)
 
-    def list_tools(self, category: str | None = None, allowed: list[str] | None = None) -> list[ToolDefinition]:
+    def list_tools(
+        self,
+        category: str | None = None,
+        allowed: list[str] | None = None,
+        role_id: str | None = None,
+    ) -> list[ToolDefinition]:
         tools = list(self._tools.values())
         if category:
             tools = [t for t in tools if t.category == category]
         if allowed:
             tools = [t for t in tools if t.name in allowed]
+        if role_id is not None:
+            tools = [t for t in tools if t.allows_role(role_id)]
         return tools
 
-    def get_schemas(self, allowed: list[str] | None = None) -> list[dict[str, Any]]:
-        tools = self.list_tools(allowed=allowed)
+    def get_schemas(
+        self,
+        allowed: list[str] | None = None,
+        role_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        tools = self.list_tools(allowed=allowed, role_id=role_id)
         return [t.to_schema() for t in tools]
+
+    def has_role_scoped_tools(self) -> bool:
+        return any(tool.allowed_roles for tool in self._tools.values())
 
     def set_approval_callback(self, callback: Any) -> None:
         self._approval_callback = callback
@@ -151,6 +180,9 @@ class ToolRegistry:
         tool = self._tools.get(name)
         if not tool:
             return {"error": f"Unknown tool: {name}", "success": False}
+        scope_error = self._role_scope_error(tool, task)
+        if scope_error:
+            return scope_error
 
         if self._approval_callback and not skip_approval:
             allowed, decision = await self._approval_callback(tool, arguments, task, on_progress)
@@ -180,6 +212,9 @@ class ToolRegistry:
         tool = self._tools.get(name)
         if not tool:
             return {"error": f"Unknown tool: {name}", "success": False}
+        scope_error = self._role_scope_error(tool, task)
+        if scope_error:
+            return scope_error
 
         try:
             call_args = self._prepare_call_args(tool, arguments, task=task, on_progress=on_progress)
@@ -203,6 +238,23 @@ class ToolRegistry:
             }
 
         return self._truncate_output(output, tool=tool, task=task)
+
+    @staticmethod
+    def _role_scope_error(tool: ToolDefinition, task: Any) -> dict[str, Any] | None:
+        if not tool.allowed_roles:
+            return None
+        role_id = str(
+            getattr(task, "_tool_scope_role_id", "") if task is not None else ""
+        ).strip()
+        if tool.allows_role(role_id):
+            return None
+        return {
+            "error": (
+                f"Tool `{tool.name}` is not available to runtime role "
+                f"`{role_id or 'unknown'}`"
+            ),
+            "success": False,
+        }
 
     def _prepare_call_args(
         self,

--- a/opc/mcp_client.py
+++ b/opc/mcp_client.py
@@ -265,6 +265,7 @@ class MCPManager:
         self,
         conn: _MCPConnectionBase,
         tool_filter: set[str] | None = None,
+        allowed_roles: list[str] | None = None,
     ) -> list[ToolDefinition]:
         raw_tools = await conn.discover_tools()
         definitions: list[ToolDefinition] = []
@@ -280,6 +281,7 @@ class MCPManager:
                 parameters=tool_spec.get("inputSchema", {"type": "object", "properties": {}}),
                 func=self._make_caller(conn, original_name),
                 category="mcp",
+                allowed_roles=allowed_roles,
             )
             definitions.append(td)
         return definitions

--- a/tests/test_mcp_access_scopes.py
+++ b/tests/test_mcp_access_scopes.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from opc.core.config import MCPServerConfig, OPCConfig
+from opc.core.models import Task
+from opc.engine import OPCEngine
+from opc.layer4_tools.registry import ToolDefinition, ToolRegistry
+
+
+async def _ok_tool() -> dict[str, bool]:
+    return {"ok": True}
+
+
+class _FakeMCPManager:
+    def __init__(self) -> None:
+        self.connect_calls: list[dict[str, object]] = []
+        self.register_calls: list[dict[str, object]] = []
+
+    async def connect_local(self, **kwargs: object) -> SimpleNamespace:
+        self.connect_calls.append(kwargs)
+        return SimpleNamespace(name=str(kwargs["name"]))
+
+    async def register_tools(
+        self,
+        conn: SimpleNamespace,
+        tool_filter: set[str] | None = None,
+        allowed_roles: list[str] | None = None,
+    ) -> list[ToolDefinition]:
+        self.register_calls.append(
+            {
+                "connection": conn.name,
+                "tool_filter": tool_filter,
+                "allowed_roles": allowed_roles,
+            }
+        )
+        return []
+
+
+class MCPAccessScopeTests(unittest.IsolatedAsyncioTestCase):
+    def test_empty_scopes_preserve_global_behavior(self) -> None:
+        server = MCPServerConfig(name="knowledge")
+        config = OPCConfig()
+        engine = OPCEngine(config=config, project_id="research")
+
+        self.assertTrue(engine._mcp_server_matches_runtime_scope(server))
+
+    def test_organization_and_project_must_both_match(self) -> None:
+        server = MCPServerConfig(
+            name="knowledge",
+            organizations=["org-a"],
+            projects=["research"],
+        )
+        config = OPCConfig()
+        config.org.organization_id = "org-a"
+
+        self.assertTrue(
+            OPCEngine(config=config, project_id="research")
+            ._mcp_server_matches_runtime_scope(server)
+        )
+        self.assertFalse(
+            OPCEngine(config=config, project_id="other")
+            ._mcp_server_matches_runtime_scope(server)
+        )
+
+    async def test_role_scope_filters_schema_and_dispatch(self) -> None:
+        registry = ToolRegistry()
+        registry.register(
+            ToolDefinition(
+                name="graph_read",
+                description="Read the graph",
+                parameters={},
+                func=_ok_tool,
+                allowed_roles=["researcher"],
+            )
+        )
+
+        self.assertEqual(
+            [schema["name"] for schema in registry.get_schemas(role_id="researcher")],
+            ["graph_read"],
+        )
+        self.assertEqual(registry.get_schemas(role_id="marketing"), [])
+
+        trusted_task = Task(assigned_to="marketing")
+        trusted_task._tool_scope_role_id = "researcher"
+        allowed = await registry.execute(
+            "graph_read",
+            {},
+            task=trusted_task,
+        )
+        denied = await registry.execute(
+            "graph_read",
+            {},
+            task=Task(assigned_to="marketing"),
+        )
+        missing_context = await registry.execute("graph_read", {})
+
+        self.assertTrue(allowed["success"])
+        self.assertFalse(denied["success"])
+        self.assertFalse(missing_context["success"])
+
+    async def test_task_assignment_cannot_forge_runtime_role(self) -> None:
+        registry = ToolRegistry()
+        registry.register(
+            ToolDefinition(
+                name="graph_read",
+                description="Read the graph",
+                parameters={},
+                func=_ok_tool,
+                allowed_roles=["researcher"],
+            )
+        )
+
+        result = await registry.execute(
+            "graph_read",
+            {},
+            task=Task(assigned_to="researcher"),
+        )
+
+        self.assertFalse(result["success"])
+
+    async def test_runtime_owned_role_overrides_task_assignment(self) -> None:
+        registry = ToolRegistry()
+        registry.register(
+            ToolDefinition(
+                name="graph_read",
+                description="Read the graph",
+                parameters={},
+                func=_ok_tool,
+                allowed_roles=["researcher"],
+            )
+        )
+        task = Task(assigned_to="marketing")
+        task._tool_scope_role_id = "researcher"
+
+        result = await registry.execute("graph_read", {}, task=task)
+
+        self.assertTrue(result["success"])
+
+    async def test_mismatched_server_is_not_started(self) -> None:
+        config = OPCConfig()
+        config.org.organization_id = "org-a"
+        config.system.mcp_servers = [
+            MCPServerConfig(
+                name="restricted",
+                command=["server-command"],
+                organizations=["org-b"],
+            )
+        ]
+        engine = OPCEngine(config=config, project_id="research")
+        manager = _FakeMCPManager()
+        engine.mcp_manager = manager
+
+        await engine._register_mcp_tools()
+
+        self.assertEqual(manager.connect_calls, [])
+        self.assertEqual(manager.register_calls, [])
+
+    async def test_matching_server_passes_role_scope_to_tools(self) -> None:
+        config = OPCConfig()
+        config.org.organization_id = "org-a"
+        config.system.mcp_servers = [
+            MCPServerConfig(
+                name="restricted",
+                command=["server-command"],
+                organizations=["org-a"],
+                projects=["research"],
+                roles=["researcher"],
+            )
+        ]
+        engine = OPCEngine(config=config, project_id="research")
+        manager = _FakeMCPManager()
+        engine.mcp_manager = manager
+
+        await engine._register_mcp_tools()
+
+        self.assertEqual(len(manager.connect_calls), 1)
+        self.assertEqual(manager.register_calls[0]["allowed_roles"], ["researcher"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add optional `organizations`, `projects`, and `roles` scopes to each MCP server config
- skip out-of-scope servers before connecting, so unrelated runtimes do not start the server or touch its credentials
- filter role-scoped tools before schema exposure and enforce the same scope again at dispatch time
- preserve existing global behavior when scope lists are empty; support `*` as a wildcard
- document the configuration and fail-closed role behavior

## Security boundary

Role authorization comes from a runtime-owned task attribute set by `NativeAgent`, not model-authored tool arguments or task metadata. A scoped tool with no trusted runtime role is denied. Organization and project checks happen before the MCP connection is created.

This intentionally does not add per-tool policy beyond the existing `tools_filter`; the server scope and allowlist compose without changing current configurations.

## Validation

- `19 passed`: MCP scope tests + task-mode contract tests
- `21 passed, 2 deselected`: affected native tool stack tests; two Windows secure-workspace cases were excluded because this platform cannot enforce the repository's POSIX workspace primitives
- new test file passes Ruff
- `compileall` passes
- `git diff --check` passes

Closes #42