### PR TITLE
feat(adapters): add dsh (DeepSeek Harness) external execution agent

### DIFF
--- a/config/agent_config.yaml
+++ b/config/agent_config.yaml
@@ -6,6 +6,7 @@ external_agents:
     - opencode
     - jiuwen
     - jiuwenswarm
+    - dsh
 
   # model_flag, new_session_flag, resume_session_flag depend on your CLI version.
   # Leave empty for CLI defaults, or set explicitly for deterministic behavior.
@@ -94,6 +95,28 @@ external_agents:
     run_mode: interactive
     interactive_timeout_seconds: 21600
     approval_mode: full-auto
+    extra_args: []
+
+  # dsh is the DeepSeek Harness agent, driven through the ACP wrapper
+  # (approval bridge + progress + resume). `transport: cli` falls back to the
+  # one-shot headless CLI. It needs `dsh` on PATH and the harness credentials
+  # resolvable from $DSH_HOME/.credentials.yaml or env.
+  dsh:
+    enabled: true
+    command: dsh
+    transport: acp
+
+  # dshswarm runs the same dsh runtime as one opaque execution team.
+  dshswarm:
+    enabled: true
+    command: dsh
+    transport: acp
+    model: ""
+    session_mode: auto
+    session_id: ""
+    run_mode: batch
+    interactive_timeout_seconds: 21600
+    approval_mode: auto
     extra_args: []
 
 native_subagents:

--- a/opc/core/config.py
+++ b/opc/core/config.py
@@ -379,7 +379,8 @@ class ExternalAgentConfig(BaseModel):
     # Optional provider-specific transport/runtime settings.  They are kept
     # on the shared external-agent model so project-local YAML can configure
     # Jiuwen without importing Jiuwen/OpenJiuwen into the OpenOPC process.
-    transport: Literal["cli", "gateway"] = "cli"
+    # ``acp`` is the dsh ACP-wrapper transport (approval bridge + progress).
+    transport: Literal["cli", "gateway", "acp"] = "cli"
     gateway_url: str = ""
     provider_mode: str = ""
     project_dir: str = ""
@@ -388,7 +389,7 @@ class ExternalAgentConfig(BaseModel):
 
 
 class AgentsConfig(BaseModel):
-    preferred_order: list[str] = Field(default_factory=lambda: ["claude_code", "cursor", "codex", "opencode", "jiuwen", "jiuwenswarm"])
+    preferred_order: list[str] = Field(default_factory=lambda: ["claude_code", "cursor", "codex", "opencode", "jiuwen", "jiuwenswarm", "dsh"])
     agents: dict[str, ExternalAgentConfig] = Field(default_factory=lambda: {
         "claude_code": ExternalAgentConfig(command="claude", run_mode="interactive", approval_mode="full-auto"),
         "cursor": ExternalAgentConfig(command="cursor-agent", run_mode="interactive", approval_mode="full-auto"),
@@ -419,6 +420,12 @@ class AgentsConfig(BaseModel):
             provider_mode="team",
             interactive_timeout_seconds=21600,
         ),
+        # ``dsh`` is the DeepSeek Harness agent driven through the ACP wrapper
+        # (approval bridge + progress + resume); ``transport: cli`` falls back
+        # to the one-shot headless CLI.
+        "dsh": ExternalAgentConfig(command="dsh", run_mode="batch", transport="acp"),
+        # ``dshswarm`` is the same runtime as one opaque execution team.
+        "dshswarm": ExternalAgentConfig(command="dsh", run_mode="batch", transport="acp"),
     })
     native_subagents: dict[str, "NativeSubagentProfileConfig"] = Field(default_factory=dict)
 

--- a/opc/core/execution_agents.py
+++ b/opc/core/execution_agents.py
@@ -19,6 +19,8 @@ EXTERNAL_EXECUTION_AGENTS: frozenset[str] = frozenset({
     "opencode",
     "jiuwen",
     "jiuwenswarm",
+    "dsh",
+    "dshswarm",
 })
 EXECUTION_AGENTS: frozenset[str] = frozenset({
     NATIVE_EXECUTION_AGENT,
@@ -32,6 +34,8 @@ EXECUTION_AGENT_LABELS: dict[str, str] = {
     "opencode": "OpenCode",
     "jiuwen": "JiuwenSwarm-single",
     "jiuwenswarm": "JiuwenSwarm-team",
+    "dsh": "DeepSeek Harness",
+    "dshswarm": "DeepSeek Harness Team",
 }
 
 

--- a/opc/layer3_agent/adapters/assets/dsh/team/cordis.yml
+++ b/opc/layer3_agent/adapters/assets/dsh/team/cordis.yml
@@ -1,0 +1,160 @@
+# DeepSeek Harness "team" profile — opaque execution team for OpenOPC.
+#
+# Installed into the isolated DSH_HOME (agent_homes/dsh/profiles/team/) by the
+# dshswarm adapter. The agent coordinates subagents as an opaque team and must
+# finish every task with a single JSON envelope so OpenOPC can project the
+# team result (work item, deliverables, verification, risks, handoff).
+- id: settings
+  name: '@deepseek-ai/dsh-settings-file'
+
+- id: credentials
+  name: '@deepseek-ai/dsh-credentials-local'
+
+- id: deepseek-llm-api-extensions
+  name: '@deepseek-ai/dsh-deepseek-llm-api-extensions'
+
+- id: session-log-deepseek
+  name: '@deepseek-ai/dsh-session-log-deepseek'
+
+- id: plugin-package-inventory-deepseek
+  name: '@deepseek-ai/dsh-plugin-package-inventory-deepseek'
+
+- id: llm-deepseek
+  name: '@deepseek-ai/dsh-llm-deepseek'
+  config:
+    thinking: enabled
+    reasoningEffort: high
+    models:
+      - id: deepseek-v4-pro
+        contextWindow: 128000
+      - id: deepseek-v4-flash
+        contextWindow: 128000
+
+- id: subprocess
+  name: '@deepseek-ai/dsh-subprocess-local'
+
+- id: bash
+  name: '@deepseek-ai/dsh-bash-local'
+  config:
+    timeoutMs: 60000
+
+- id: agent-spine
+  name: '@deepseek-ai/dsh-agent-spine-demo'
+  config:
+    agents:
+      - id: main
+        provider: deepseek-official
+        model: deepseek-v4-flash
+        cwd: !!js process.cwd()
+    workspaceContext:
+      maxBytes: 65536
+    persona: |
+      You are the coordinator of an AI team running inside OpenOPC as one
+      opaque execution unit ("DeepSeek Harness Team"). Decompose the task,
+      dispatch independent parts to parallel subagents (the subagent tool),
+      review their results, and assemble one final deliverable set.
+
+      When the task is finished, reply with EXACTLY ONE JSON object (nothing
+      before or after it) shaped like this:
+
+      {
+        "work_item_id": "<opc work item id if known, else the task id>",
+        "attempt_id": "<stable attempt id>",
+        "status": "done | failed | blocked",
+        "summary": "one concise paragraph describing what the team delivered",
+        "deliverables": [
+          {"kind": "file|directory|report|url", "name": "...", "path": "/absolute/path", "description": "..."}
+        ],
+        "verification": {"verdict": "pass|fail|unknown", "command": "how it was verified", "evidence": "..."},
+        "risks": ["..."],
+        "open_questions": ["..."],
+        "handoff": "what the human owner should review next"
+      }
+
+      The JSON object is the team's result contract; keep every field.
+
+- id: persistence
+  name: '@deepseek-ai/dsh-session-persistence-jsonl'
+  config:
+    root: './.sessions'
+    compression: !!js "process.env.DSH_SNAPSHOT === undefined ? 'zstd' : 'none'"
+
+- id: checkpoint-policy
+  name: '@deepseek-ai/dsh-session-checkpoint-policy'
+
+- id: token-meter
+  name: '@deepseek-ai/dsh-token-meter'
+
+- id: compaction-basic
+  name: '@deepseek-ai/dsh-compaction-basic'
+  config:
+    thresholdRatio: 0.8
+    retainRatio: 0.16
+    maxTokens: 8192
+    compactionRetries: 1
+
+- id: session-projection
+  name: '@deepseek-ai/dsh-session-projection'
+
+- id: subagent
+  name: '@deepseek-ai/dsh-subagent'
+
+- id: subagent-spawn-in-process
+  name: '@deepseek-ai/dsh-subagent-spawn-in-process'
+  config:
+    providerName: spawn
+
+- id: subagent-fork-in-process
+  name: '@deepseek-ai/dsh-subagent-fork-in-process'
+  config:
+    providerName: fork
+
+- id: tool-subagent-control
+  name: '@deepseek-ai/dsh-tool-subagent-control'
+
+- id: tool-subagent-report
+  name: '@deepseek-ai/dsh-tool-subagent-report'
+
+- id: tool-subagent
+  name: '@deepseek-ai/dsh-tool-subagent'
+  config:
+    provider: spawn
+    toolName: subagent
+    backgroundMode: continuable
+    maxDepth: 2
+
+- id: tool-subagent-fork
+  name: '@deepseek-ai/dsh-tool-subagent'
+  config:
+    provider: fork
+    toolName: subagent_fork
+    backgroundMode: one-shot
+    enableRunInBackground: false
+    maxDepth: 2
+
+- id: workflow-worker-thread
+  name: '@deepseek-ai/dsh-workflow-worker-thread'
+  config:
+    provider: spawn
+
+- id: tool-workflow
+  name: '@deepseek-ai/dsh-tool-workflow'
+
+- id: tool-ralph
+  name: '@deepseek-ai/dsh-tool-ralph'
+
+- id: tool-todo
+  name: '@deepseek-ai/dsh-tool-todo'
+  config:
+    allowParallelInProgress: true
+
+- id: fs-local
+  name: '@deepseek-ai/dsh-fs-local'
+  config:
+    cwd: !!js process.cwd()
+
+- id: fs-observation-policy
+  name: '@deepseek-ai/dsh-fs-observation-policy'
+
+- id: tool-fs
+  name: '@deepseek-ai/dsh-tool-fs'

--- a/opc/layer3_agent/adapters/dsh_acp_wrapper.py
+++ b/opc/layer3_agent/adapters/dsh_acp_wrapper.py
@@ -1,0 +1,318 @@
+"""dsh ACP wrapper — bridges dsh's ACP stdio server into OpenOPC's line protocol.
+
+The external broker drives external agents as one subprocess per task whose
+stdout is read line by line and whose stdin accepts approval responses. dsh's
+ACP server is a long-lived JSON-RPC stdio process, so this wrapper sits
+between them: it spawns ``dsh --profile acp``, performs the ``session/new`` +
+``session/prompt`` handshake, forwards semantic progress and permission
+requests as JSON lines on stdout, relays the broker's approval decisions back
+over ACP, and exits when the prompt settles — restoring the broker's
+"process exit marks completion" contract.
+
+Wrapper stdout protocol (one JSON object per line):
+
+- ``{"type": "progress", "text": "..."}`` — a semantic progress update.
+- ``{"type": "approval", "callId": <int>, "toolName": "...", "arguments": {...},
+   "promptText": "..."}`` — an ACP ``session/request_permission``; the broker
+  answers with one approval-response line on stdin.
+- ``{"type": "session", "id": "..."}`` — the created/resumed ACP session id.
+
+Wrapper stdin protocol:
+
+- ``{"type": "approval_response", "callId": <int>, "allowed": true|false}``
+
+The wrapper itself never times out: the broker owns idle/hard timeouts and
+terminates this process when they fire.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import threading
+from typing import Any
+
+_DEFAULT_DSH_CMD = "dsh"
+_ACP_PROFILE = "acp"
+_NEW_SESSION_ID = 1
+_PROMPT_ID = 2
+
+_ALLOW_ONCE = "allow-once"
+_REJECT_ONCE = "reject-once"
+
+
+def _emit(obj: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(obj, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def _extract_update_text(update: dict[str, Any]) -> str:
+    """Concatenate committed text blocks from a dsh ``session/update`` payload.
+
+    dsh emits ``content`` both as a single block object (agent_thought_chunk /
+    agent_message_chunk) and as a list, so accept either shape.
+    """
+    content = update.get("content")
+    if isinstance(content, list):
+        blocks = content
+    elif isinstance(content, dict):
+        blocks = [content]
+    else:
+        return ""
+    parts: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+    return "\n".join(parts)
+
+
+async def _write_json(writer: asyncio.StreamWriter, obj: dict[str, Any]) -> None:
+    writer.write((json.dumps(obj, ensure_ascii=False) + "\n").encode("utf-8"))
+    await writer.drain()
+
+
+async def _read_json_lines(reader: asyncio.StreamReader):
+    while True:
+        line = await reader.readline()
+        if not line:
+            return
+        text = line.decode("utf-8", errors="replace").strip()
+        if not text:
+            continue
+        try:
+            yield json.loads(text)
+        except json.JSONDecodeError:
+            continue
+
+
+async def _rpc(
+    writer: asyncio.StreamWriter,
+    reader: asyncio.StreamReader,
+    request_id: int,
+    method: str,
+    params: dict[str, Any],
+) -> dict[str, Any] | None:
+    await _write_json(writer, {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+    async for message in _read_json_lines(reader):
+        if message.get("id") == request_id:
+            return message
+    return None
+
+
+def _build_outcome(allowed: bool) -> dict[str, Any]:
+    option_id = _ALLOW_ONCE if allowed else _REJECT_ONCE
+    outcome = "allowed" if allowed else "rejected"
+    return {"outcome": outcome, "optionId": option_id}
+
+
+async def _wait_approval_response(
+    queue: asyncio.Queue[dict[str, Any] | None],
+    call_id: int,
+) -> bool:
+    while True:
+        message = await queue.get()
+        if message is None:
+            # stdin closed before a response arrived; reject rather than wait.
+            return False
+        if not isinstance(message, dict):
+            continue
+        if message.get("type") != "approval_response":
+            continue
+        if str(message.get("callId") or "") != str(call_id):
+            continue
+        return bool(message.get("allowed"))
+
+
+async def _approval_message_text(params: dict[str, Any]) -> str:
+    tool_call = params.get("toolCall") or {}
+    tool_id = str(tool_call.get("toolCallId") or "")
+    return f"dsh requested tool permission (call {tool_id})"
+
+
+async def _run(
+    dsh_cmd: str,
+    cwd: str,
+    prompt: str,
+    resume_session_id: str,
+    approval: str,
+) -> int:
+    env = dict(os.environ)
+    proc = await asyncio.create_subprocess_exec(
+        dsh_cmd,
+        "--profile",
+        _ACP_PROFILE,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+        env=env,
+    )
+    if proc.stdin is None or proc.stdout is None:
+        return 2
+    writer, reader = proc.stdin, proc.stdout
+
+    async def _relay_stderr() -> None:
+        assert proc.stderr is not None
+        while True:
+            chunk = await proc.stderr.read(4096)
+            if not chunk:
+                return
+            sys.stderr.buffer.write(chunk)
+            sys.stderr.buffer.flush()
+
+    stderr_task = asyncio.create_task(_relay_stderr())
+    incoming_queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+    loop = asyncio.get_running_loop()
+
+    def _deliver(message: dict[str, Any] | None) -> None:
+        # asyncio.Queue is not thread-safe; always enqueue on the event loop.
+        incoming_queue.put_nowait(message)
+
+    def _read_stdin_sync() -> None:
+        # Raw os.read never takes the BufferedReader lock, so a daemon thread
+        # blocked here cannot deadlock interpreter shutdown. Threaded reads
+        # work for any stdin fd (pipe, tty, /dev/null).
+        buffer = b""
+        try:
+            while True:
+                chunk = os.read(0, 65536)
+                if not chunk:
+                    break
+                buffer += chunk
+                while b"\n" in buffer:
+                    line, buffer = buffer.split(b"\n", 1)
+                    text = line.decode("utf-8", errors="replace").strip()
+                    if not text:
+                        continue
+                    try:
+                        loop.call_soon_threadsafe(_deliver, json.loads(text))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            pass
+        finally:
+            try:
+                loop.call_soon_threadsafe(_deliver, None)  # EOF: no more responses
+            except RuntimeError:
+                pass
+
+    # Daemon thread: when stdin never reaches EOF (broker keeps the pipe open)
+    # the interpreter must still exit after the prompt settles.
+    stdin_task = threading.Thread(target=_read_stdin_sync, name="dsh-wrapper-stdin", daemon=True)
+    stdin_task.start()
+
+    try:
+        if resume_session_id:
+            response = await _rpc(writer, reader, _NEW_SESSION_ID, "session/resume", {"sessionId": resume_session_id, "cwd": cwd, "mcpServers": []})
+            if response is None or "error" in response:
+                _emit({"type": "fatal", "reason": "session handshake failed", "detail": response})
+                return 2
+            # dsh's session/resume result carries no sessionId; the resumed
+            # session keeps the requested id.
+            session_id = resume_session_id
+        else:
+            response = await _rpc(writer, reader, _NEW_SESSION_ID, "session/new", {"cwd": cwd, "mcpServers": []})
+            if response is None or "error" in response:
+                _emit({"type": "fatal", "reason": "session handshake failed", "detail": response})
+                return 2
+            result = response.get("result") or {}
+            session_id = str(result.get("sessionId") or "")
+            if not session_id:
+                _emit({"type": "fatal", "reason": "session/new returned no sessionId"})
+                return 2
+        _emit({"type": "session", "id": session_id})
+
+        await _write_json(
+            writer,
+            {
+                "jsonrpc": "2.0",
+                "id": _PROMPT_ID,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": prompt}],
+                },
+            },
+        )
+
+        async for message in _read_json_lines(reader):
+            if message.get("id") == _PROMPT_ID:
+                if "error" in message:
+                    _emit({"type": "fatal", "reason": "session/prompt failed", "detail": message.get("error")})
+                    return 2
+                return 0
+            method = str(message.get("method") or "")
+            if method == "session/request_permission":
+                call_id = message.get("id")
+                params = dict(message.get("params") or {})
+                tool_call = dict(params.get("toolCall") or {})
+                tool_name = str(tool_call.get("name") or "dsh_tool_call")
+                arguments = dict(tool_call.get("arguments") or {})
+                _emit(
+                    {
+                        "type": "approval",
+                        "callId": call_id,
+                        "toolName": tool_name,
+                        "arguments": arguments,
+                        "promptText": await _approval_message_text(params),
+                    }
+                )
+                allowed = approval == "auto"
+                if approval == "bridge":
+                    # EOF (None) inside _wait_approval_response rejects.
+                    allowed = await _wait_approval_response(incoming_queue, call_id)
+                await _write_json(
+                    writer,
+                    {"jsonrpc": "2.0", "id": call_id, "result": _build_outcome(allowed)},
+                )
+            elif method == "session/update":
+                params = dict(message.get("params") or {})
+                update = dict(params.get("update") or {})
+                text = _extract_update_text(update)
+                if text:
+                    _emit({"type": "progress", "text": text})
+        return 0
+    finally:
+        stderr_task.cancel()
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                proc.kill()
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="dsh-acp-wrapper", description=__doc__)
+    parser.add_argument("--dsh-cmd", default="", help="dsh executable path (default: $DSH_CMD or 'dsh')")
+    parser.add_argument("--cwd", required=True, help="workspace the dsh agent runs in")
+    parser.add_argument("--resume", default="", help="resume an existing ACP session id")
+    parser.add_argument(
+        "--approval",
+        choices=("bridge", "auto", "reject"),
+        default="bridge",
+        help="bridge: relay decisions to OpenOPC (broker path); auto/reject: decide locally (headless execute path)",
+    )
+    parser.add_argument("prompt", help="the task prompt for the dsh agent")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(list(argv) if argv is not None else sys.argv[1:])
+    dsh_cmd = str(args.dsh_cmd or os.environ.get("DSH_CMD") or _DEFAULT_DSH_CMD).strip() or _DEFAULT_DSH_CMD
+    try:
+        return asyncio.run(_run(dsh_cmd, args.cwd, args.prompt, args.resume, args.approval))
+    except FileNotFoundError:
+        sys.stderr.write(f"dsh-acp-wrapper: executable not found: {dsh_cmd}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/opc/layer3_agent/adapters/dsh_adapter.py
+++ b/opc/layer3_agent/adapters/dsh_adapter.py
@@ -1,0 +1,560 @@
+"""DeepSeek Harness (dsh) external agent adapter — ACP wrapper transport.
+
+v2 drives ``dsh --profile acp`` through ``dsh_acp_wrapper`` (a small
+out-of-process ACP client). The wrapper restores the OpenOPC approval-card
+bridge (``session/request_permission`` -> ``ExternalApprovalRequest``),
+forwards semantic progress (``session/update`` text), supports session resume,
+and exits when the prompt settles so the broker's "process exit marks
+completion" contract holds. ``transport: cli`` falls back to the v1 one-shot
+headless CLI (no approval bridge).
+
+Deferred:
+- Company-mode external-execution workspace fence (``supports_company_execution``).
+- Opaque-team execution unit (``execution_unit_kind = "opaque_external_team"``).
+- Automatic provider-session resume via the broker's persisted session tokens
+  (``--resume`` is already wired; session-id plumbing lands with it).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from opc.core.config import ExternalAgentConfig, get_opc_home
+from opc.core.models import AgentStatus, Task, TaskResult, TaskStatus
+from opc.layer2_organization.work_item_links import linked_work_item_id_for_task
+from opc.layer3_agent.adapters.base import (
+    ExternalAgentAdapter,
+    ExternalApprovalRequest,
+)
+
+_ACP_PROFILE = "acp"
+_HEADLESS_PROFILE = "headless"
+_WRAPPER_MODULE = "opc.layer3_agent.adapters.dsh_acp_wrapper"
+_TRANSPORT_ACP = "acp"
+_TRANSPORT_CLI = "cli"
+
+
+class DshAdapter(ExternalAgentAdapter):
+    """Drive a DeepSeek Harness agent through its ACP stdio server."""
+
+    agent_type = "dsh"
+    default_command = "dsh"
+
+    def __init__(self, config: ExternalAgentConfig | None = None) -> None:
+        super().__init__(config)
+        self._process: asyncio.subprocess.Process | None = None
+
+    # ------------------------------------------------------------------
+    # Transport selection
+    # ------------------------------------------------------------------
+
+    def _transport(self) -> str:
+        configured = str(getattr(self.config, "transport", "") or "").strip().lower()
+        if configured in {_TRANSPORT_ACP, _TRANSPORT_CLI}:
+            return configured
+        return _TRANSPORT_ACP
+
+    def _resume_session_id(self, task: Task | None = None) -> str:
+        session_id = str(self.config.session_id or "").strip()
+        if session_id:
+            return session_id
+        if task is not None:
+            metadata = dict(getattr(task, "metadata", {}) or {})
+            return str(metadata.get("provider_session_id") or "").strip()
+        return ""
+
+    # ------------------------------------------------------------------
+    # Capability surface
+    # ------------------------------------------------------------------
+
+    def execution_unit_kind(self) -> str:
+        return "external_agent"
+
+    def supports_company_execution(self) -> bool:
+        # The broker honors this together with the durable company
+        # external-execution fence (capture -> run -> validate); the wrapper's
+        # --cwd already pins the validated workspace for each session/new.
+        return True
+
+    def build_task_prompt(self, task: Task) -> str:
+        """Prefix resumed conversations so dsh treats the message as a follow-up.
+
+        OpenOPC task mode sends each user message as its own task brief with no
+        conversation history; continuity comes from the resumed dsh ACP session.
+        When the task snapshot marks this run as a same-session resume, instruct
+        dsh to treat the brief as the latest turn of the ongoing conversation
+        and to use its session memory of earlier messages.
+        """
+        prompt = super().build_task_prompt(task)
+        snapshot = dict(getattr(task, "context_snapshot", None) or {})
+        runtime_resume = dict(snapshot.get("runtime_resume") or {})
+        if runtime_resume.get("restored_from_same_session"):
+            return (
+                "You are continuing an ongoing OpenOPC conversation; earlier "
+                "messages and your replies are in your session memory. Treat the "
+                "following as the user's latest message in that conversation. "
+                "Reply in Simplified Chinese.\n\n"
+                f"{prompt}"
+            )
+        return prompt
+
+    def supports_interactive(self) -> bool:
+        return False
+
+    def supports_session_resume(self) -> bool:
+        return self._transport() == _TRANSPORT_ACP
+
+    def supports_approval_prompt_handling(
+        self,
+        cmd: list[str],
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        # The ACP wrapper relays approval decisions over its stdin pipe; the
+        # headless transport has no live approval channel.
+        return self._transport() == _TRANSPORT_ACP
+
+    def agent_isolation_home_slug(self) -> str:
+        # Isolated DSH_HOME keeps dsh settings, credentials, and session state
+        # out of the user's default dsh installation.
+        return self.agent_type
+
+    def agent_home_env_vars(self, home: str) -> dict[str, str]:
+        return {"DSH_HOME": str(home), "DSH_CMD": self.configured_command()}
+
+    def build_process_env(self, extra_env: dict[str, str] | None = None) -> dict[str, str]:
+        # Always pin DSH_HOME to the isolated agent home (opc_home/agent_homes/
+        # dsh/) so dsh resolves credentials, settings, and sessions there even
+        # when the broker's opc-collab env injection is not active.
+        env = dict(os.environ)
+        if extra_env:
+            env.update({str(key): str(value) for key, value in extra_env.items()})
+        home = get_opc_home() / "agent_homes" / self.agent_isolation_home_slug()
+        env["DSH_HOME"] = str(home)
+        return env
+
+    # ------------------------------------------------------------------
+    # Invocation
+    # ------------------------------------------------------------------
+
+    def build_invocation(
+        self,
+        task: Task,
+        workspace_path: str | None = None,
+    ) -> tuple[list[str], dict[str, Any]]:
+        prompt = self.build_task_prompt(task)
+        workspace = str(Path(workspace_path or os.getcwd()).expanduser().resolve())
+        if self._transport() == _TRANSPORT_CLI:
+            cmd = [self.configured_command(), "--profile", _HEADLESS_PROFILE]
+            cmd.extend(str(arg) for arg in (self.config.extra_args or []))
+            cmd.append(prompt)
+            metadata: dict[str, Any] = {
+                "transport": "cli",
+                "profile": _HEADLESS_PROFILE,
+                "prompt_transport": "argv",
+            }
+            return cmd, metadata
+        cmd = [sys.executable, "-m", _WRAPPER_MODULE, "--cwd", workspace, "--dsh-cmd", self.configured_command()]
+        resume_id = self._resume_session_id(task)
+        if resume_id:
+            cmd.extend(["--resume", resume_id])
+        cmd.extend(str(arg) for arg in (self.config.extra_args or []))
+        cmd.extend(["--", prompt])
+        metadata = {
+            "transport": "acp",
+            "profile": _ACP_PROFILE,
+            "prompt_transport": "wrapper_argv",
+            "resume_session_id": resume_id,
+            "stdin_policy": "pipe_open",
+        }
+        return cmd, metadata
+
+    def stdin_policy_for_process(
+        self,
+        cmd: list[str],
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        if self._transport() == _TRANSPORT_ACP:
+            return "pipe_open"
+        return "devnull"
+
+    async def is_available(self) -> bool:
+        return self.resolve_binary() is not None
+
+    async def get_status(self) -> AgentStatus:
+        if self._process is not None and self._process.returncode is None:
+            return AgentStatus.RUNNING
+        return AgentStatus.IDLE
+
+    # ------------------------------------------------------------------
+    # Line protocol bridging (ACP wrapper)
+    # ------------------------------------------------------------------
+
+    def parse_approval_request(
+        self,
+        text: str,
+        stream_name: str = "",
+    ) -> ExternalApprovalRequest | None:
+        """Parse an ACP-wrapper approval event line into a normalized request."""
+        _ = stream_name
+        try:
+            obj = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if not isinstance(obj, dict) or obj.get("type") != "approval":
+            return None
+        tool_name = str(obj.get("toolName") or "dsh_tool_call")
+        return ExternalApprovalRequest(
+            approval_scope="tool",
+            action_name=tool_name,
+            prompt_text=str(obj.get("promptText") or ""),
+            arguments=dict(obj.get("arguments") or {}),
+            metadata={"call_id": str(obj.get("callId") or ""), "transport": "dsh_acp"},
+            raw_text=text,
+        )
+
+    def format_approval_response(
+        self,
+        request: ExternalApprovalRequest,
+        approved: bool,
+        decision: Any,
+    ) -> str:
+        """Format an approval-response line the ACP wrapper relays to dsh."""
+        call_id = str((request.metadata or {}).get("call_id") or "")
+        if not call_id:
+            return super().format_approval_response(request, approved, decision)
+        return json.dumps(
+            {"type": "approval_response", "callId": call_id, "allowed": bool(approved)},
+            ensure_ascii=False,
+        ) + "\n"
+
+    def format_progress_update(self, text: str, stream_name: str = "") -> str | None:
+        """Extract a progress text from an ACP-wrapper progress event line."""
+        _ = stream_name
+        try:
+            obj = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if not isinstance(obj, dict) or obj.get("type") != "progress":
+            return None
+        progress = str(obj.get("text") or "")
+        return progress.strip() or None
+
+    def normalize_result_output(self, output: str) -> str:
+        """Project the wrapper's protocol lines back to plain user-facing text.
+
+        The ACP wrapper emits one JSON object per line (session / progress /
+        approval) and the broker collects those raw lines into the final
+        response. Keep semantic progress text, drop protocol-only lines
+        (session, approval, resume bookkeeping), surface fatal reasons, and
+        pass non-JSON lines through unchanged.
+        """
+        parts: list[str] = []
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except (json.JSONDecodeError, TypeError):
+                parts.append(stripped)
+                continue
+            if not isinstance(obj, dict):
+                parts.append(stripped)
+                continue
+            kind = obj.get("type")
+            if kind == "progress":
+                text = str(obj.get("text") or "").strip()
+                if text:
+                    parts.append(text)
+                continue
+            if kind == "fatal":
+                reason = str(obj.get("reason") or "").strip()
+                if reason:
+                    parts.append(f"dsh fatal: {reason}")
+                continue
+            # session / approval / other protocol lines are not user-facing
+        return "\n".join(parts)
+
+    def extract_resume_session_id(self, output: str) -> str:
+        """Grab the ACP session id emitted by the wrapper on handshake."""
+        for line in output.splitlines():
+            try:
+                obj = json.loads(line)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(obj, dict) and obj.get("type") == "session":
+                session_id = str(obj.get("id") or "")
+                if session_id:
+                    return session_id
+        return ""
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    async def execute(self, task: Task, workspace_path: str) -> TaskResult:
+        if not await self.is_available():
+            return TaskResult(status=TaskStatus.FAILED, content="dsh executable not found")
+        cmd, metadata = self.build_invocation(task, workspace_path=workspace_path)
+        approval_mode = str(self.config.approval_mode or "auto").strip().lower()
+        if self._transport() == _TRANSPORT_ACP:
+            # Without the broker approval bridge, decide locally so the wrapper
+            # never waits on an approval response nobody will send: auto-allow
+            # permissive modes, reject everything else.
+            approval_flag = "auto" if approval_mode in {"auto", "full-auto"} else "reject"
+            cmd = [*cmd[:-2], "--approval", approval_flag, *cmd[-2:]]
+        try:
+            self._process = await self.start_process(
+                cmd,
+                workspace_path,
+                task=task,
+                launch_metadata=metadata,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                self._process.communicate(),
+                timeout=max(1, int(self.config.interactive_timeout_seconds or 900)),
+            )
+            output = stdout.decode("utf-8", errors="replace")
+            errors = stderr.decode("utf-8", errors="replace")
+            if self._process.returncode == 0:
+                result = self.normalize_result_output(output)
+                session_id = self.extract_resume_session_id(output)
+                if session_id:
+                    metadata["provider_session_id"] = session_id
+                return TaskResult(
+                    status=TaskStatus.DONE,
+                    content=result,
+                    artifacts=metadata,
+                )
+            return TaskResult(
+                status=TaskStatus.FAILED,
+                content=(
+                    f"dsh exited with code {self._process.returncode}\n"
+                    f"{errors}\n{output}"
+                ),
+                artifacts=metadata,
+            )
+        except asyncio.TimeoutError:
+            if self._process is not None and self._process.returncode is None:
+                self._process.kill()
+            return TaskResult(status=TaskStatus.FAILED, content="dsh timed out", artifacts=metadata)
+        except Exception as exc:  # noqa: BLE001 - surface any launch failure to the caller
+            return TaskResult(status=TaskStatus.FAILED, content=f"dsh error: {exc}", artifacts=metadata)
+        finally:
+            self._process = None
+
+    async def cancel(self, task_id: str) -> bool:
+        if self._process is not None and self._process.returncode is None:
+            self._process.kill()
+        return True
+
+
+_TEAM_PROFILE_SOURCE = Path(__file__).resolve().parent / "assets" / "dsh" / "team" / "cordis.yml"
+
+
+class DshSwarmAdapter(DshAdapter):
+    """Opaque DeepSeek Harness Team adapter (one OpenOPC execution unit).
+
+    Runs the dsh ``team`` profile (an agent that decomposes work across its own
+    subagents and must close with a single JSON envelope), so OpenOPC treats
+    the whole run as one opaque team: the broker owns the work item, while the
+    dsh team owns every internal teammate and subtask. Team results project
+    through the same envelope contract as JiuwenSwarm-team.
+    """
+
+    agent_type = "dshswarm"
+    default_command = "dsh"
+    _TEAM_PROFILE = "team"
+
+    def execution_unit_kind(self) -> str:
+        return "opaque_external_team"
+
+    def supports_company_execution(self) -> bool:
+        return True
+
+    def agent_isolation_home_slug(self) -> str:
+        # Same runtime as the single-agent dsh: share the isolated DSH_HOME so
+        # credentials, settings, and the team profile resolve consistently.
+        return "dsh"
+
+    def _ensure_team_profile(self) -> None:
+        """Install the team profile into the isolated DSH_HOME if missing."""
+        target = get_opc_home() / "agent_homes" / self.agent_isolation_home_slug() / "profiles" / self._TEAM_PROFILE / "cordis.yml"
+        try:
+            if target.exists():
+                return
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(_TEAM_PROFILE_SOURCE.read_text(encoding="utf-8"), encoding="utf-8")
+        except OSError:
+            pass
+
+    def build_invocation(
+        self,
+        task: Task,
+        workspace_path: str | None = None,
+    ) -> tuple[list[str], dict[str, Any]]:
+        self._ensure_team_profile()
+        prompt = self.build_task_prompt(task)
+        workspace = str(Path(workspace_path or os.getcwd()).expanduser().resolve())
+        cmd = [sys.executable, "-m", _WRAPPER_MODULE, "--cwd", workspace, "--dsh-cmd", self.configured_command()]
+        cmd.extend(str(arg) for arg in (self.config.extra_args or []))
+        cmd.extend(["--", prompt])
+        metadata: dict[str, Any] = {
+            "transport": "acp",
+            "profile": self._TEAM_PROFILE,
+            "prompt_transport": "wrapper_argv",
+            "stdin_policy": "pipe_open",
+        }
+        return cmd, metadata
+
+    # ------------------------------------------------------------------
+    # Team envelope contract (mirrors JiuwenSwarm-team)
+    # ------------------------------------------------------------------
+
+    _TEAM_ENVELOPE_REQUIRED = frozenset({
+        "work_item_id",
+        "attempt_id",
+        "status",
+        "summary",
+        "deliverables",
+        "verification",
+        "risks",
+        "open_questions",
+        "handoff",
+    })
+
+    @staticmethod
+    def _normalize_team_sequence(value: Any) -> list[Any]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return list(value)
+        if isinstance(value, (dict, str)):
+            return [value] if value not in ("", {}) else []
+        return [value]
+
+    @classmethod
+    def _team_result_envelope(cls, output: str) -> dict[str, Any]:
+        envelope: dict[str, Any] = {}
+        for candidate in cls._iter_json_object_candidates(output):
+            if isinstance(candidate, dict) and cls._TEAM_ENVELOPE_REQUIRED.issubset(candidate):
+                envelope = dict(candidate)
+        if envelope:
+            for key in ("deliverables", "risks", "open_questions"):
+                envelope[key] = cls._normalize_team_sequence(envelope.get(key))
+        return envelope
+
+    @staticmethod
+    def _artifact_index_from_deliverables(value: Any) -> list[dict[str, str]]:
+        artifacts: list[dict[str, str]] = []
+        for item in list(value or []):
+            if isinstance(item, str) and item.strip():
+                artifacts.append({"kind": "deliverable", "label": "deliverable", "value": item.strip()})
+                continue
+            if not isinstance(item, dict):
+                continue
+            location = str(
+                item.get("path")
+                or item.get("location")
+                or item.get("value")
+                or item.get("url")
+                or item.get("directory_path")
+                or ""
+            ).strip()
+            if location:
+                artifacts.append({
+                    "kind": str(item.get("kind") or "deliverable").strip() or "deliverable",
+                    "label": str(item.get("name") or item.get("label") or "deliverable").strip() or "deliverable",
+                    "value": location,
+                })
+            for nested_key in ("files", "artifacts", "outputs", "deliverables"):
+                nested = item.get(nested_key)
+                if nested not in (None, "", [], {}):
+                    artifacts.extend(
+                        DshSwarmAdapter._artifact_index_from_deliverables(
+                            nested if isinstance(nested, list) else [nested]
+                        )
+                    )
+        return artifacts[:24]
+
+    @staticmethod
+    def _verification_evidence(value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            return {}
+        verdict = str(value.get("verdict") or "").strip().lower().replace("-", "_").replace(" ", "_")
+        if verdict not in {"pass", "passed", "success", "fail", "failed", "unknown", "pending", "blocked"}:
+            verdict = "unknown"
+        evidence = str(value.get("evidence") or value.get("command") or value.get("summary") or "").strip()
+        return {"verdict": verdict, "evidence": evidence} if evidence else {"verdict": verdict}
+
+    def extract_structured_result_fields(self, output: str) -> dict[str, Any]:
+        structured = super().extract_structured_result_fields(output)
+        envelope = self._team_result_envelope(output)
+        if not envelope:
+            return structured
+        structured["opaque_external_team_result"] = envelope
+        artifact_index = self._artifact_index_from_deliverables(envelope.get("deliverables"))
+        if artifact_index:
+            structured["work_item_artifact_index"] = artifact_index
+        verification = self._verification_evidence(envelope.get("verification"))
+        if verification:
+            structured["verification_evidence"] = verification
+        return structured
+
+    def validate_result_output(self, output: str, task: Task) -> str | None:
+        metadata = dict(task.metadata or {})
+        company_mode = bool(
+            str(metadata.get("execution_mode") or "").strip() == "company_mode"
+            or str(metadata.get("runtime_model") or "").strip() == "multi_team_org"
+            or str(metadata.get("mode") or "").strip() in {"company", "org", "custom"}
+        )
+        if (
+            str(metadata.get("execution_unit_kind", "") or "").strip()
+            != "opaque_external_team"
+            or not company_mode
+        ):
+            return None
+        envelope = self._team_result_envelope(output)
+        if not envelope:
+            return (
+                "dshswarm completed without the required OpenOPC output envelope "
+                "(attempt_id, deliverables, handoff, open_questions, risks, status, "
+                "summary, verification, work_item_id)"
+            )
+        expected_work_item_id = linked_work_item_id_for_task(task)
+        actual_work_item_id = str(envelope.get("work_item_id") or "").strip()
+        if expected_work_item_id and actual_work_item_id != expected_work_item_id:
+            return (
+                "dshswarm output envelope work_item_id mismatch: "
+                f"expected {expected_work_item_id!r}, got {actual_work_item_id!r}"
+            )
+        expected_attempt_id = str(
+            (task.metadata or {}).get("attempt_id")
+            or (task.metadata or {}).get("claimed_work_item_attempt_seq")
+            or ""
+        ).strip()
+        actual_attempt_id = str(envelope.get("attempt_id") or "").strip()
+        if not actual_attempt_id:
+            return "dshswarm output envelope attempt_id must not be empty"
+        if expected_attempt_id and actual_attempt_id != expected_attempt_id:
+            return (
+                "dshswarm output envelope attempt_id mismatch: "
+                f"expected {expected_attempt_id!r}, got {actual_attempt_id!r}"
+            )
+        status = str(envelope.get("status") or "").strip().lower()
+        if status not in {"complete", "completed", "done", "success", "partial", "blocked", "failed"}:
+            return f"dshswarm output envelope has unsupported status {status!r}"
+        if status in {"blocked", "failed"}:
+            return f"dshswarm reported terminal status {status!r}: {str(envelope.get('summary') or '').strip()}"
+        if not str(envelope.get("summary") or "").strip():
+            return "dshswarm output envelope summary must not be empty"
+        if not isinstance(envelope.get("verification"), (dict, list, str, type(None))):
+            return "dshswarm output envelope verification must be an object, list, string, or null"
+        if not isinstance(envelope.get("handoff"), (dict, list, str, type(None))):
+            return "dshswarm output envelope handoff must be an object, list, string, or null"
+        return None

--- a/opc/layer3_agent/adapters/registry.py
+++ b/opc/layer3_agent/adapters/registry.py
@@ -12,6 +12,7 @@ from opc.layer3_agent.adapters.cursor_adapter import CursorAdapter
 from opc.layer3_agent.adapters.codex_adapter import CodexAdapter
 from opc.layer3_agent.adapters.opencode_adapter import OpenCodeAdapter
 from opc.layer3_agent.adapters.jiuwen_adapter import JiuwenAdapter, JiuwenSwarmAdapter
+from opc.layer3_agent.adapters.dsh_adapter import DshAdapter, DshSwarmAdapter
 
 
 ADAPTER_CLASSES: dict[str, type[ExternalAgentAdapter]] = {
@@ -21,6 +22,8 @@ ADAPTER_CLASSES: dict[str, type[ExternalAgentAdapter]] = {
     "opencode": OpenCodeAdapter,
     "jiuwen": JiuwenAdapter,
     "jiuwenswarm": JiuwenSwarmAdapter,
+    "dsh": DshAdapter,
+    "dshswarm": DshSwarmAdapter,
 }
 
 if frozenset(ADAPTER_CLASSES) != EXTERNAL_EXECUTION_AGENTS:

--- a/opc/layer3_agent/preflight.py
+++ b/opc/layer3_agent/preflight.py
@@ -451,6 +451,11 @@ def _probe_help_flags(
     result: ExternalAgentPreflightResult,
 ) -> None:
     args = _HELP_COMMANDS.get(agent_name, ("--help",))
+    if launch_cmd and str(launch_cmd[0] or "") != str(binary or ""):
+        # launch_cmd begins with an interpreter or wrapper other than the
+        # probed binary (for example ``python -m <module>``); its --help can
+        # never advertise the harness flags, so skip the flag check.
+        return
     try:
         proc = subprocess.run(
             [binary, *args],

--- a/tests/test_dsh_adapter.py
+++ b/tests/test_dsh_adapter.py
@@ -1,0 +1,293 @@
+"""dsh external-agent adapter: ACP wrapper protocol tests.
+
+These tests exercise the full line-protocol contract without a real dsh
+installation or API key: a fake ``dsh --profile acp`` server drives the
+wrapper through session handshake, semantic progress, the approval bridge,
+and clean exit. The adapter-side parse/format helpers are tested directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+from opc.core.config import AgentsConfig
+from opc.layer3_agent.adapters.dsh_adapter import DshAdapter
+
+FAKE_DSH_SERVER = r'''#!/usr/bin/env python3
+import json, sys
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+def read():
+    line = sys.stdin.readline()
+    return json.loads(line) if line.strip() else None
+
+while True:
+    msg = read()
+    if msg is None:
+        break
+    mid, method = msg.get("id"), msg.get("method")
+    if method == "session/new":
+        send({"jsonrpc": "2.0", "id": mid, "result": {"sessionId": "sess-123"}})
+    elif method == "session/prompt":
+        send({"jsonrpc": "2.0", "method": "session/update", "params": {
+            "sessionId": "sess-123",
+            "update": {"content": [{"type": "text", "text": "Starting the work..."}]}}})
+        send({"jsonrpc": "2.0", "id": 100, "method": "session/request_permission", "params": {
+            "sessionId": "sess-123",
+            "toolCall": {"toolCallId": "call-1"},
+            "options": [{"optionId": "allow-once", "name": "Allow once", "kind": "allow_once"},
+                        {"optionId": "reject-once", "name": "Reject", "kind": "reject_once"}]}})
+        resp = read()
+        assert resp.get("id") == 100, resp
+        send({"jsonrpc": "2.0", "method": "session/update", "params": {
+            "sessionId": "sess-123",
+            "update": {"content": [{"type": "text", "text": "Permission granted, continuing..."}]}}})
+        send({"jsonrpc": "2.0", "id": mid, "result": {"ok": True}})
+    elif method == "session/resume":
+        assert "cwd" in msg["params"], "resume must carry cwd"
+        # Real dsh returns an empty result on resume; the session keeps the
+        # requested id, so the wrapper must not demand a sessionId back.
+        send({"jsonrpc": "2.0", "id": mid, "result": {}})
+    else:
+        send({"jsonrpc": "2.0", "id": mid, "error": {"code": -32601, "message": "unknown"}})
+'''
+
+
+@pytest.fixture()
+def fake_dsh_server(tmp_path):
+    path = tmp_path / "fake_dsh_server.py"
+    path.write_text(FAKE_DSH_SERVER, encoding="utf-8")
+    path.chmod(0o755)
+    return str(path)
+
+
+def _wait_for_line(proc, want_type, timeout=10):
+    deadline = __import__("time").time() + timeout
+    seen = []
+    while __import__("time").time() < deadline:
+        line = proc.stdout.readline()
+        if not line:
+            break
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            seen.append(line.strip())
+            continue
+        seen.append(obj)
+        if isinstance(obj, dict) and obj.get("type") == want_type:
+            return obj, seen
+    raise AssertionError(
+        f"did not see {want_type} in {timeout}s; saw: {seen}; "
+        f"stderr={proc.stderr.read() if proc.poll() is not None else '<still running>'}"
+    )
+
+
+def _run_wrapper(fake_dsh_server, cwd, *extra, env=None):
+    merged = dict(os.environ)
+    merged["DSH_CMD"] = fake_dsh_server
+    if env:
+        merged.update(env)
+    return subprocess.Popen(
+        [sys.executable, "-m", "opc.layer3_agent.adapters.dsh_acp_wrapper",
+         "--cwd", cwd, *extra, "--", "Do the thing"],
+        cwd=os.getcwd(),
+        env=merged,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def test_wrapper_handshake_progress_approval_and_exit(fake_dsh_server, tmp_path):
+    """The wrapper bridges session id, progress, approval, and exits cleanly."""
+    proc = _run_wrapper(fake_dsh_server, str(tmp_path))
+    sess, _ = _wait_for_line(proc, "session")
+    assert sess["id"] == "sess-123"
+    prog, _ = _wait_for_line(proc, "progress")
+    assert "Starting" in prog["text"]
+    approval, _ = _wait_for_line(proc, "approval")
+    assert approval["callId"] == 100
+    assert proc.stdin is not None
+    proc.stdin.write(json.dumps({"type": "approval_response", "callId": 100, "allowed": True}) + "\n")
+    proc.stdin.flush()
+    prog2, _ = _wait_for_line(proc, "progress")
+    assert "continuing" in prog2["text"]
+    rc = proc.wait(timeout=10)
+    assert rc == 0, f"wrapper exit {rc}; stderr={proc.stderr.read()}"
+
+
+def test_wrapper_resume_handshake(fake_dsh_server, tmp_path):
+    """--resume routes through session/resume and keeps the provided id."""
+    proc = _run_wrapper(fake_dsh_server, str(tmp_path), "--resume", "sess-old")
+    sess, _ = _wait_for_line(proc, "session")
+    assert sess["id"] == "sess-old"
+    proc.kill()
+
+
+def test_wrapper_rejects_when_approval_mode_is_restrictive(fake_dsh_server, tmp_path):
+    """--approval reject decides locally instead of waiting on the bridge."""
+    proc = _run_wrapper(fake_dsh_server, str(tmp_path), "--approval", "reject")
+    _wait_for_line(proc, "session")
+    _wait_for_line(proc, "approval")
+    # No approval response is written; the wrapper must still finish.
+    rc = proc.wait(timeout=10)
+    assert rc == 0, f"wrapper exit {rc}; stderr={proc.stderr.read()}"
+
+
+def test_adapter_line_bridge_roundtrip():
+    """parse/format/progress/resume helpers speak the wrapper's line protocol."""
+    cfg = AgentsConfig()
+    adapter = DshAdapter(config=cfg.agents["dsh"])
+    assert adapter._transport() == "acp"
+    assert adapter.supports_approval_prompt_handling([], {})
+    assert adapter.supports_session_resume()
+
+    request = adapter.parse_approval_request(
+        json.dumps({"type": "approval", "callId": 100, "toolName": "bash",
+                    "arguments": {"cmd": "ls"}, "promptText": "run?"})
+    )
+    assert request is not None
+    assert request.approval_scope == "tool"
+    assert request.action_name == "bash"
+    assert request.metadata["call_id"] == "100"
+    response = adapter.format_approval_response(request, True, None)
+    assert json.loads(response) == {"type": "approval_response", "callId": "100", "allowed": True}
+
+    assert adapter.format_progress_update('{"type":"progress","text":"hi"}') == "hi"
+    assert adapter.format_progress_update("plain text") is None
+
+    raw = (
+        '{"type": "session", "id": "s-1"}\n'
+        '{"type": "progress", "text": "Thinking..."}\n'
+        '{"type": "approval", "callId": 1, "toolName": "bash", "arguments": {}}\n'
+        '{"type": "progress", "text": "FORMAT-CHECK"}\n'
+        "plain fallback line\n"
+    )
+    normalized = adapter.normalize_result_output(raw)
+    assert "session" not in normalized and "approval" not in normalized
+    assert "Thinking..." in normalized and "FORMAT-CHECK" in normalized
+    assert normalized.count("plain fallback line") == 1
+    assert adapter.extract_resume_session_id('{"type":"session","id":"sess-9"}') == "sess-9"
+
+
+def test_build_task_prompt_adds_resume_guidance_for_same_session():
+    """Resumed conversations tell dsh the brief is a follow-up, not a new task."""
+    cfg = AgentsConfig()
+    adapter = DshAdapter(config=cfg.agents["dsh"])
+
+    def make_task(snapshot):
+        return type("T", (), {
+            "title": "Latest message",
+            "description": "Latest message",
+            "metadata": {},
+            "context_snapshot": snapshot,
+        })()
+
+    plain = make_task(None)
+    assert adapter.build_task_prompt(plain) == "Latest message"
+
+    resumed = make_task({"runtime_resume": {"restored_from_same_session": True}})
+    prompt = adapter.build_task_prompt(resumed)
+    assert "continuing an ongoing OpenOPC conversation" in prompt
+    assert prompt.endswith("Latest message")
+
+    not_resumed = make_task({"runtime_resume": {"restored_from_same_session": False}})
+    assert adapter.build_task_prompt(not_resumed) == "Latest message"
+
+
+def test_adapter_build_invocation_uses_wrapper_by_default():
+    """Default transport composes the wrapper command with cwd and prompt."""
+    cfg = AgentsConfig()
+    adapter = DshAdapter(config=cfg.agents["dsh"])
+    task = type("T", (), {"title": "Title", "description": "Desc", "metadata": {}})()
+    cmd, metadata = adapter.build_invocation(task, "/tmp/ws")
+    assert any("dsh_acp_wrapper" in part for part in cmd)
+    assert "--cwd" in cmd and cmd[cmd.index("--cwd") + 1].endswith("/ws")
+    assert cmd[-2:] == ["--", "Title\n\nDesc"]
+    assert metadata["transport"] == "acp"
+
+
+def test_dshswarm_team_envelope_parsing():
+    """dshswarm projects the team envelope into structured result fields."""
+    from opc.layer3_agent.adapters.dsh_adapter import DshSwarmAdapter
+    cfg = AgentsConfig()
+    adapter = DshSwarmAdapter(config=cfg.agents["dshswarm"])
+    assert adapter.execution_unit_kind() == "opaque_external_team"
+    assert adapter.supports_company_execution() is True
+
+    output = (
+        "some prose before\n"
+        + json.dumps({
+            "work_item_id": "wi-1",
+            "attempt_id": "a-7",
+            "status": "done",
+            "summary": "团队完成了任务",
+            "deliverables": [
+                {"kind": "file", "name": "report.md", "path": "/ws/report.md", "description": "报告"},
+            ],
+            "verification": {"verdict": "pass", "command": "pytest"},
+            "risks": ["风险"],
+            "open_questions": [],
+            "handoff": "请查看报告",
+        })
+        + "\nmore prose"
+    )
+    structured = adapter.extract_structured_result_fields(output)
+    assert structured["opaque_external_team_result"]["work_item_id"] == "wi-1"
+    assert structured["opaque_external_team_result"]["status"] == "done"
+    assert structured["work_item_artifact_index"][0]["value"] == "/ws/report.md"
+    assert structured["verification_evidence"]["verdict"] == "pass"
+
+    # company-mode validation passes for a complete envelope
+    task = type("T", (), {
+        "metadata": {"execution_mode": "company_mode", "execution_unit_kind": "opaque_external_team", "attempt_id": "a-7"},
+        "title": "", "description": "", "context_snapshot": {},
+    })()
+    assert adapter.validate_result_output(output, task) is None
+
+    # mismatch on work_item_id is rejected
+    task2 = type("T", (), {
+        "metadata": {"execution_mode": "company_mode", "execution_unit_kind": "opaque_external_team", "attempt_id": "a-7"},
+        "title": "", "description": "",
+        "context_snapshot": {},
+    })()
+    import opc.layer3_agent.adapters.dsh_adapter as dsh_mod
+    from opc.layer2_organization.work_item_links import linked_work_item_id_for_task
+    # simulate linked work item by patching the helper
+    orig = linked_work_item_id_for_task
+    try:
+        dsh_mod.linked_work_item_id_for_task = lambda t: "wi-expected"
+        err = adapter.validate_result_output(output, task2)
+        assert err and "work_item_id mismatch" in err
+    finally:
+        dsh_mod.linked_work_item_id_for_task = orig
+
+
+def test_dshswarm_build_invocation_uses_team_profile():
+    """dshswarm composes the wrapper invocation with the team profile."""
+    from opc.layer3_agent.adapters.dsh_adapter import DshSwarmAdapter
+    cfg = AgentsConfig()
+    adapter = DshSwarmAdapter(config=cfg.agents["dshswarm"])
+    task = type("T", (), {"title": "T", "description": "D", "metadata": {}, "context_snapshot": {}})()
+    cmd, metadata = adapter.build_invocation(task, "/tmp/ws")
+    assert any("dsh_acp_wrapper" in part for part in cmd)
+    assert metadata["profile"] == "team"
+    assert "--cwd" in cmd and cmd[cmd.index("--cwd") + 1].endswith("/ws")
+
+
+def test_dsh_supports_company_execution():
+    """Company fence capability is on for the single-agent dsh adapter."""
+    cfg = AgentsConfig()
+    from opc.layer3_agent.adapters.dsh_adapter import DshAdapter
+    adapter = DshAdapter(config=cfg.agents["dsh"])
+    assert adapter.supports_company_execution() is True


### PR DESCRIPTION
## Summary

Adds `dsh` (DeepSeek Harness) as an external company execution agent for OpenOPC, alongside the existing `claude_code` / `codex` / `cursor` / `opencode` / `jiuwen` adapters.

## What's included

- **`opc/layer3_agent/adapters/dsh_adapter.py`** — `DshAdapter` / `DshSwarmAdapter` over an ACP transport: result normalization, structured-field extraction, resume-session handling, approval-prompt support, company-execution capability.
- **`opc/layer3_agent/adapters/dsh_acp_wrapper.py`** — wrapper bridging the OpenOPC approval flow with dsh ACP progress + session resume (`transport: acp`); a `transport: cli` one-shot headless fallback is also supported.
- **`opc/layer3_agent/adapters/assets/dsh/team/cordis.yml`** — harness team profile used for `dshswarm` (opaque-team) execution.
- **Registration** — `opc/core/config.py` allows `transport: "acp"` on `ExternalAgentConfig` and ships default `dsh` / `dshswarm` entries; `opc/core/execution_agents.py` and `adapters/registry.py` register both agents; `config/agent_config.yaml` enables them.
- **`opc/layer3_agent/preflight.py`** — small fix: skip `--help` flag probing when the launch command starts with an interpreter/wrapper (e.g. `python -m …`) rather than the probed binary, which can never advertise the harness flags.
- **`tests/test_dsh_adapter.py`** — 9 unit tests (prompt building, invocation, resume guidance, result normalization, team envelope parsing, company-execution support).

## Requirements

`dsh` must be on `PATH` with the harness credentials resolvable from `$DSH_HOME/.credentials.yaml` or the environment. The agent is only used when enabled in `config/agent_config.yaml`, so the default experience is unchanged.

## Notes

- All 9 unit tests pass (`pytest tests/test_dsh_adapter.py`).
- Base-adapter compatibility: the new code only relies on the pre-existing `ExternalAgentAdapter` interface; upstream additions since (e.g. `result_validation_retry_strategy`) are not required by this adapter.
